### PR TITLE
Refactor to use a config object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Use `Config` instead of standalone arguments ([#45](https://github.com/stac-utils/stac-asset/pull/45))
+- s/CantIncludeAndExclude/CannotIncludeAndExclude/ ([#45](https://github.com/stac-utils/stac-asset/pull/45))
+
 ### Removed
 
 - USGS EROS client ([#37](https://github.com/stac-utils/stac-asset/pull/37))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,6 @@ import importlib.metadata
 project = "stac-asset"
 copyright = "2023, Pete Gadomski"
 author = "Pete Gadomski"
-release = "v0.0.1"
 version = importlib.metadata.version("stac_asset")
 release = importlib.metadata.version("stac_asset")
 

--- a/src/stac_asset/__init__.py
+++ b/src/stac_asset/__init__.py
@@ -11,11 +11,12 @@ the roadmap.
 
 
 from .client import Client
+from .config import Config
 from .earthdata_client import EarthdataClient
 from .errors import (
     AssetDownloadError,
     AssetOverwriteError,
-    CantIncludeAndExclude,
+    CannotIncludeAndExclude,
     DownloadError,
     DownloadWarning,
 )
@@ -34,8 +35,9 @@ __all__ = [
     "DownloadWarning",
     "AssetDownloadError",
     "AssetOverwriteError",
-    "CantIncludeAndExclude",
+    "CannotIncludeAndExclude",
     "Client",
+    "Config",
     "DownloadError",
     "EarthdataClient",
     "FileNameStrategy",

--- a/src/stac_asset/_cli.py
+++ b/src/stac_asset/_cli.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Union
 import click
 from pystac import Item, ItemCollection
 
-from . import functions
+from . import Config, functions
 
 
 @click.group()
@@ -30,6 +30,7 @@ def cli() -> None:
     help="Asset keys to exclude (can't be used with include)",
     multiple=True,
 )
+@click.option("-f", "--file-name", help="The output file name")
 @click.option(
     "-q",
     "--quiet",
@@ -58,6 +59,7 @@ def download(
     directory: Optional[str],
     include: List[str],
     exclude: List[str],
+    file_name: Optional[str],
     quiet: bool,
     s3_requester_pays: bool,
     warn: bool,
@@ -88,6 +90,14 @@ def download(
     if directory is None:
         directory = os.getcwd()
 
+    config = Config(
+        include=include,
+        exclude=exclude,
+        file_name=file_name,
+        s3_requester_pays=s3_requester_pays,
+        warn=warn,
+    )
+
     type_ = input_dict.get("type")
     if type_ is None:
         print("ERROR: missing 'type' field on input dictionary", file=sys.stderr)
@@ -101,11 +111,7 @@ def download(
             functions.download_item(
                 item,
                 directory,
-                include=include or None,
-                exclude=exclude or None,
-                item_file_name=None,
-                s3_requester_pays=s3_requester_pays,
-                warn_on_download_error=warn,
+                config=config,
             )
         )
     elif type_ == "FeatureCollection":
@@ -114,11 +120,7 @@ def download(
             functions.download_item_collection(
                 item_collection,
                 directory,
-                include=include or None,
-                exclude=exclude or None,
-                item_collection_file_name=None,
-                s3_requester_pays=s3_requester_pays,
-                warn_on_download_error=warn,
+                config=config,
             )
         )
     else:

--- a/src/stac_asset/client.py
+++ b/src/stac_asset/client.py
@@ -102,7 +102,6 @@ class Client(ABC):
             path: The path to which the asset will be downloaded
 
         Raises:
-            ValueError: Raised if the asset does not have an absolute href
             AssetDownloadError: If any exception is raised during the
                 download, it is wrapped in an :py:class:`AssetDownloadError`
         """

--- a/src/stac_asset/config.py
+++ b/src/stac_asset/config.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from .errors import CannotIncludeAndExclude
+from .strategy import FileNameStrategy
+
+
+@dataclass
+class Config:
+    """Configuration for downloading items and their assets."""
+
+    asset_file_name_strategy: FileNameStrategy = FileNameStrategy.FILE_NAME
+    """The file name strategy to use when downloading assets."""
+
+    exclude: List[str] = field(default_factory=list)
+    """Assets to exclude from the download.
+
+    Mutually exclusive with ``include``.
+    """
+
+    include: List[str] = field(default_factory=list)
+    """Assets to include in the download.
+
+    Mutually exclusive with ``exclude``.
+    """
+
+    file_name: Optional[str] = None
+    """The file name of the output item.
+
+    If not provided, the output item will not be saved.
+    """
+
+    make_directory: bool = True
+    """Whether to create the output directory.
+
+    If False, and the output directory does not exist, an error will be raised.
+    """
+
+    warn: bool = False
+    """When downloading, warn instead of erroring."""
+
+    s3_requester_pays: bool = False
+    """If using the s3 client, enable requester pays."""
+
+    def validate(self) -> None:
+        """Validates this configuration.
+
+        Raises:
+            CannotIncludeAndExclude: ``include`` and ``exclude`` are mutually exclusive
+        """
+        if self.include and self.exclude:
+            raise CannotIncludeAndExclude(include=self.include, exclude=self.exclude)
+
+    def copy(self) -> Config:
+        """Returns a deep copy of this config.
+
+        Returns:
+            Config: A deep copy of this config.
+        """
+        return copy.deepcopy(self)

--- a/src/stac_asset/errors.py
+++ b/src/stac_asset/errors.py
@@ -33,12 +33,17 @@ class DownloadWarning(Warning):
     """
 
 
-class CantIncludeAndExclude(Exception):
+class CannotIncludeAndExclude(Exception):
     """Raised if both include and exclude are passed to download."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self, include: List[str], exclude: List[str], *args: Any, **kwargs: Any
+    ) -> None:
         super().__init__(
-            "can't use include and exclude in the same download call", *args, **kwargs
+            "can't use include and exclude in the same download call: "
+            f"include={include}, exclude={exclude}",
+            *args,
+            **kwargs,
         )
 
 

--- a/src/stac_asset/functions.py
+++ b/src/stac_asset/functions.py
@@ -1,45 +1,28 @@
-from typing import List, Optional
+from typing import Optional
 
 from pystac import Item, ItemCollection
 from yarl import URL
 
 from .client import Client
+from .config import Config
 from .filesystem_client import FilesystemClient
 from .http_client import HttpClient
 from .planetary_computer_client import PlanetaryComputerClient
 from .s3_client import S3Client
-from .strategy import FileNameStrategy
 from .types import PathLikeObject
 
 
 async def download_item(
     item: Item,
     directory: PathLikeObject,
-    *,
-    make_directory: bool = False,
-    include: Optional[List[str]] = None,
-    exclude: Optional[List[str]] = None,
-    item_file_name: Optional[str] = None,
-    include_self_link: bool = True,
-    s3_requester_pays: bool = False,
-    warn_on_download_error: bool = False,
+    config: Optional[Config] = None,
 ) -> Item:
     """Downloads an item to the local filesystem.
 
     Args:
         item: The :py:class:`pystac.Item`.
         directory: The output directory that will hold the items and assets.
-        make_directory: Whether to create the directory if it doesn't exist.
-        include: Asset keys to download. If not provided, all asset keys
-            will be downloaded.
-        exclude: Asset keys to not download. If not provided, all asset keys
-            will be downloaded.
-        item_file_name: The file name of the output item. If not provided, will
-            default to the item's id with a .json extension.
-        include_self_link: Whether to include a self link in the output item.
-        s3_requester_pays: If using the s3 client, enable requester pays
-        warn_on_download_error: Instead of raising any errors encountered while
-            downloading, warn and delete the asset from the item
+        config: The download configuration
 
     Returns:
         Item: The `~pystac.Item`, with the updated asset hrefs.
@@ -49,49 +32,30 @@ async def download_item(
     """
     if not item.assets:
         raise ValueError("cannot guess a client if an item does not have any assets")
+    if config is None:
+        config = Config()
     async with await guess_client(
-        next(iter(item.assets.values())).href, s3_requester_pays=s3_requester_pays
+        next(iter(item.assets.values())).href,
+        s3_requester_pays=config.s3_requester_pays,
     ) as client:
         return await client.download_item(
             item=item,
             directory=directory,
-            make_directory=make_directory,
-            include=include,
-            exclude=exclude,
-            item_file_name=item_file_name,
-            include_self_link=include_self_link,
-            warn_on_download_error=warn_on_download_error,
+            config=config,
         )
 
 
 async def download_item_collection(
     item_collection: ItemCollection,
     directory: PathLikeObject,
-    *,
-    make_directory: bool = False,
-    include: Optional[List[str]] = None,
-    exclude: Optional[List[str]] = None,
-    item_collection_file_name: Optional[str] = "item-collection.json",
-    asset_file_name_strategy: FileNameStrategy = FileNameStrategy.FILE_NAME,
-    s3_requester_pays: bool = False,
-    warn_on_download_error: bool = False,
+    config: Optional[Config] = None,
 ) -> ItemCollection:
     """Downloads an item collection to the local filesystem.
 
     Args:
         item_collection: The item collection to download
         directory: The destination directory
-        make_directory: Whether to make the directory if it does not exist
-        include: Asset keys to download. If not provided, all asset keys
-            will be downloaded.
-        exclude: Asset keys to not download. If not provided, all asset keys
-            will be downloaded.
-        item_collection_file_name: The name of the item collection JSON file. If
-            None, do not write the item collection, only download the assets.
-        asset_file_name_strategy: The strategy to use for the asset file names
-        s3_requester_pays: If using the s3 client, enable requester pays
-        warn_on_download_error: Instead of raising any errors encountered while
-            downloading, warn and delete the asset from the item
+        config: The download configuration
 
     Returns:
         ItemCollection: The item collection, with updated asset hrefs
@@ -99,6 +63,8 @@ async def download_item_collection(
     Raises:
         CantIncludeAndExclude: Raised if both include and exclude are not None.
     """
+    if config is None:
+        config = Config()
     if not item_collection.items:
         return item_collection
     elif not item_collection.items[0].assets:
@@ -108,17 +74,12 @@ async def download_item_collection(
         )
     async with await guess_client(
         next(iter(item_collection.items[0].assets.values())).href,
-        s3_requester_pays=s3_requester_pays,
+        s3_requester_pays=config.s3_requester_pays,
     ) as client:
         return await client.download_item_collection(
             item_collection,
             directory,
-            include=include,
-            exclude=exclude,
-            make_directory=make_directory,
-            item_collection_file_name=item_collection_file_name,
-            asset_file_name_strategy=asset_file_name_strategy,
-            warn_on_download_error=warn_on_download_error,
+            config=config,
         )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,7 +52,7 @@ def test_download_item_collection_stdin_stdout(
 
 
 @pytest.mark.network_access
-def test_download_item_s3_requester_pays(tmp_path: Path, item_path: Path) -> None:
+def test_download_item_s3_requester_pays(tmp_path: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(
         stac_asset._cli.cli,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,13 @@
+import pytest
+from stac_asset import CannotIncludeAndExclude, Config
+
+
+def test_validate_default() -> None:
+    config = Config()
+    config.validate()
+
+
+def test_validate_include_and_exclude() -> None:
+    config = Config(include=["foo"], exclude=["bar"])
+    with pytest.raises(CannotIncludeAndExclude):
+        config.validate()

--- a/tests/test_s3_client.py
+++ b/tests/test_s3_client.py
@@ -5,7 +5,7 @@ from typing import cast
 import pystac
 import pytest
 from pystac import Item
-from stac_asset import S3Client
+from stac_asset import Config, S3Client
 
 pytestmark = [
     pytest.mark.asyncio,
@@ -56,7 +56,9 @@ async def test_download_requester_pays_item(
     async with S3Client(requester_pays=True) as client:
         if not await client.has_credentials():
             pytest.skip("aws credentials are invalid or not present")
-        await client.download_item(requester_pays_item, tmp_path, include=["thumbnail"])
+        await client.download_item(
+            requester_pays_item, tmp_path, Config(include=["thumbnail"])
+        )
         assert (
             os.path.getsize(
                 tmp_path / "LC09_L2SP_092068_20230607_20230609_02_T1_thumb_small.jpeg"


### PR DESCRIPTION
## Description

We were passing around a _lot_ of arguments. This PR refactors to use a configuration object. Breaking change.

We will need to figure out a strategy for specific clients to advertise their configuration -- for now, we have an ad-hoc "use an environment variable" policy for some of them.

## Checklist

- [x] Add tests
- [x] Add docs
- [x] Update CHANGELOG
