### PR TITLE
Fix item collection asset hrefs

### DIFF
--- a/src/stac_asset/_cli.py
+++ b/src/stac_asset/_cli.py
@@ -60,6 +60,7 @@ def cli() -> None:
     is_flag=True,
     show_default=True,
 )
+# TODO add option to disable content type checking
 def download(
     href: Optional[str],
     directory: Optional[str],

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -19,7 +19,7 @@ pytestmark = [
 
 
 async def test_download_item(tmp_path: Path, item: Item) -> None:
-    item = await stac_asset.download_item(item, tmp_path)
+    item = await stac_asset.download_item(item, tmp_path, Config(file_name="item.json"))
     assert Path(tmp_path / "item.json").exists(), item.get_self_href()
     asset = item.assets["data"]
     assert asset.href == "./20201211_223832_CS2.jpg"
@@ -28,11 +28,13 @@ async def test_download_item(tmp_path: Path, item: Item) -> None:
 async def test_download_item_collection(
     tmp_path: Path, item_collection: ItemCollection
 ) -> None:
-    await stac_asset.download_item_collection(
+    item_collection = await stac_asset.download_item_collection(
         item_collection, tmp_path, Config(file_name="item-collection.json")
     )
     assert os.path.exists(tmp_path / "item-collection.json")
     assert os.path.exists(tmp_path / "test-item" / "20201211_223832_CS2.jpg")
+    asset = item_collection.items[0].assets["data"]
+    assert asset.href == "./test-item/20201211_223832_CS2.jpg"
 
 
 async def test_download_collection(tmp_path: Path, collection: Collection) -> None:


### PR DESCRIPTION
## Related issues and pull requests

- Closes #52

## Description

We were being too liberal setting an item's self href, which was leading to invalid item collection asset hrefs.

## Checklist

- [x] Add tests
- [ ] Add docs
- [ ] Update CHANGELOG
