### PR TITLE
Abstract downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Use `Config` instead of standalone arguments ([#45](https://github.com/stac-utils/stac-asset/pull/45))
 - s/CantIncludeAndExclude/CannotIncludeAndExclude/ ([#45](https://github.com/stac-utils/stac-asset/pull/45))
+- Re-use the same client for an entire item collection ([#59](https://github.com/stac-utils/stac-asset/pull/59))
 
 ### Removed
 

--- a/src/stac_asset/__init__.py
+++ b/src/stac_asset/__init__.py
@@ -25,7 +25,6 @@ from .functions import (
     download_collection,
     download_item,
     download_item_collection,
-    guess_client_class,
 )
 from .http_client import HttpClient
 from .planetary_computer_client import PlanetaryComputerClient
@@ -49,5 +48,4 @@ __all__ = [
     "download_collection",
     "download_item",
     "download_item_collection",
-    "guess_client_class",
 ]

--- a/src/stac_asset/_cli.py
+++ b/src/stac_asset/_cli.py
@@ -12,7 +12,7 @@ import click_logging
 import tqdm
 from pystac import Item, ItemCollection
 
-from . import Config, functions
+from . import Config, _download, functions
 from .config import DEFAULT_S3_MAX_ATTEMPTS, DEFAULT_S3_RETRY_MODE
 from .messages import (
     ErrorAssetDownload,
@@ -230,7 +230,7 @@ async def download_async(
 
 
 async def read_file(href: str, config: Config) -> bytes:
-    async with await functions.guess_client_class_from_href(href).from_config(
+    async with await _download.guess_client_class_from_href(href).from_config(
         config
     ) as client:
         data = b""

--- a/src/stac_asset/_download.py
+++ b/src/stac_asset/_download.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import asyncio
+import os.path
+import warnings
+from asyncio import Queue
+from dataclasses import dataclass
+from pathlib import Path
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type, Union
+
+from pystac import Asset, Collection, Item
+from yarl import URL
+
+from .client import Client
+from .config import Config
+from .errors import AssetOverwriteError, DownloadError, DownloadWarning
+from .filesystem_client import FilesystemClient
+from .http_client import HttpClient
+from .planetary_computer_client import PlanetaryComputerClient
+from .s3_client import S3Client
+from .strategy import FileNameStrategy
+
+# Needed until we drop Python 3.8
+if TYPE_CHECKING:
+    AnyQueue = Queue[Any]
+else:
+    AnyQueue = Queue
+
+
+@dataclass
+class Download:
+    owner: Union[Item, Collection]
+    key: str
+    asset: Asset
+    path: Path
+    client: Client
+
+    async def download(
+        self, make_directory: bool, clean: bool, queue: Optional[AnyQueue]
+    ) -> Union[Download, WrappedError]:
+        try:
+            await self.client.download_asset(
+                self.key, self.asset, self.path, make_directory, clean, queue
+            )
+        except Exception as error:
+            return WrappedError(self, error)
+        else:
+            return self
+
+
+class Downloads:
+    clients: Dict[Type[Client], Client]
+    config: Config
+    downloads: List[Download]
+
+    def __init__(self, config: Config) -> None:
+        config.validate()
+        self.config = config
+        self.downloads = list()
+        self.clients = dict()
+
+    async def add(self, stac_object: Union[Item, Collection], root: Path) -> None:
+        file_names: Set[str] = set()
+
+        for key, asset in (
+            (k, a)
+            for k, a in stac_object.assets.items()
+            if (not self.config.include or k in self.config.include)
+            and (not self.config.exclude or k not in self.config.exclude)
+        ):
+            if self.config.asset_file_name_strategy == FileNameStrategy.FILE_NAME:
+                file_name = os.path.basename(URL(asset.href).path)
+            elif self.config.asset_file_name_strategy == FileNameStrategy.KEY:
+                file_name = key + Path(asset.href).suffix
+
+            if file_name in file_names:
+                raise AssetOverwriteError(list(file_names))
+            else:
+                file_names.add(file_name)
+
+            client_class = guess_client_class(asset, self.config)
+            if client_class in self.clients:
+                client = self.clients[client_class]
+            else:
+                client = await client_class.from_config(self.config)
+                self.clients[client_class] = client
+
+            self.downloads.append(
+                Download(
+                    owner=stac_object,
+                    key=key,
+                    asset=asset,
+                    path=root / file_name,
+                    client=client,
+                )
+            )
+
+    async def download(self, queue: Optional[AnyQueue]) -> None:
+        tasks = set()
+        for download in self.downloads:
+            tasks.add(
+                asyncio.create_task(
+                    download.download(
+                        make_directory=self.config.make_directory,
+                        clean=self.config.clean,
+                        queue=queue,
+                    )
+                )
+            )
+        results = await asyncio.gather(*tasks)
+        exceptions = set()
+        for result in results:
+            if isinstance(result, WrappedError):
+                del result.download.owner.assets[result.download.key]
+                if self.config.warn:
+                    warnings.warn(str(result.error), DownloadWarning)
+                else:
+                    exceptions.add(result.error)
+        if exceptions:
+            raise DownloadError(list(exceptions))
+
+    async def __aenter__(self) -> Downloads:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        for client in self.clients.values():
+            await client.close()
+
+
+def guess_client_class(asset: Asset, config: Config) -> Type[Client]:
+    """Guess which client should be used to download the given asset.
+
+    If the configuration has ``alternate_assets``, these will be used instead of
+    the asset's href, if present. The asset's href will be updated with the href picked.
+
+    Args:
+        asset: The asset
+        config: A download configuration
+
+    Returns:
+        Client: The most appropriate client class for the href, maybe.
+    """
+    alternate = asset.extra_fields.get("alternate")
+    if not isinstance(alternate, dict):
+        alternate = None
+    if alternate and config.alternate_assets:
+        for alternate_asset in config.alternate_assets:
+            if alternate_asset in alternate:
+                try:
+                    href = alternate[alternate_asset]["href"]
+                    asset.extra_fields["alternate"]["original"] = {"href": href}
+                    asset.href = href
+                    return guess_client_class_from_href(href)
+                except KeyError:
+                    raise ValueError(
+                        "invalid alternate asset definition (missing href): "
+                        f"{alternate}"
+                    )
+    return guess_client_class_from_href(asset.href)
+
+
+def guess_client_class_from_href(href: str) -> Type[Client]:
+    """Guess the client class from an href.
+
+    Args:
+        href: An href
+
+    Returns:
+        A client class type.
+    """
+    url = URL(href)
+    if not url.host:
+        return FilesystemClient
+    elif url.scheme == "s3":
+        return S3Client
+    elif url.host.endswith("blob.core.windows.net"):
+        return PlanetaryComputerClient
+    elif url.scheme == "http" or url.scheme == "https":
+        return HttpClient
+    else:
+        raise ValueError(f"could not guess client class for href: {href}")
+
+
+class WrappedError:
+    download: Download
+    error: Exception
+
+    def __init__(self, download: Download, error: Exception) -> None:
+        self.download = download
+        self.error = error

--- a/src/stac_asset/errors.py
+++ b/src/stac_asset/errors.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, List
 
 
 class AssetOverwriteError(Exception):
@@ -47,13 +47,11 @@ class ContentTypeError(Exception):
 class DownloadError(Exception):
     """A collection of exceptions encountered while downloading."""
 
-    exceptions: Dict[str, Exception]
+    exceptions: List[Exception]
 
-    def __init__(
-        self, exceptions: Dict[str, Exception], *args: Any, **kwargs: Any
-    ) -> None:
+    def __init__(self, exceptions: List[Exception], *args: Any, **kwargs: Any) -> None:
         self.exceptions = exceptions
         messages = list()
-        for key, exception in exceptions.items():
-            messages.append(f"{key}: {exception}")
+        for exception in exceptions:
+            messages.append(str(exception))
         super().__init__("\n".join(messages), *args, **kwargs)

--- a/src/stac_asset/functions.py
+++ b/src/stac_asset/functions.py
@@ -1,26 +1,18 @@
-import asyncio
-import os.path
-import warnings
+import json
 from asyncio import Queue
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Tuple, Type, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Optional,
+    TypeVar,
+)
 
 import pystac.utils
-from pystac import Asset, Collection, Item, ItemCollection, STACError
-from yarl import URL
+from pystac import Collection, Item, ItemCollection, STACError
 
-from .client import Client
+from ._download import Downloads
 from .config import Config
-from .errors import (
-    AssetOverwriteError,
-    DownloadError,
-    DownloadWarning,
-)
-from .filesystem_client import FilesystemClient
-from .http_client import HttpClient
-from .planetary_computer_client import PlanetaryComputerClient
-from .s3_client import S3Client
-from .strategy import FileNameStrategy
 from .types import PathLikeObject
 
 # Needed until we drop Python 3.8
@@ -50,7 +42,37 @@ async def download_item(
     Raises:
         ValueError: Raised if the item doesn't have any assets.
     """
-    return await _download(item, directory, config=config or Config(), queue=queue)
+    return await _download_stac_object(
+        item, directory, config=config or Config(), queue=queue
+    )
+
+
+async def download_collection(
+    collection: Collection,
+    directory: PathLikeObject,
+    config: Optional[Config] = None,
+    queue: Optional[AnyQueue] = None,
+) -> Collection:
+    """Downloads a collection to the local filesystem.
+
+    Does not download the collection's items' assets -- use
+    :py:func:`download_item_collection` to download multiple items.
+
+    Args:
+        collection: A pystac collection
+        directory: The destination directory
+        config: The download configuration
+        queue: An optional queue to use for progress reporting
+
+    Returns:
+        Collection: The collection, with updated asset hrefs
+
+    Raises:
+        CantIncludeAndExclude: Raised if both include and exclude are not None.
+    """
+    return await _download_stac_object(
+        collection, directory, config or Config(), queue=queue
+    )
 
 
 async def download_item_collection(
@@ -75,233 +97,78 @@ async def download_item_collection(
     """
     if config is None:
         config = Config()
-
-    directory_as_path = Path(directory)
-    if not directory_as_path.exists():
-        if config.make_directory:
-            directory_as_path.mkdir(parents=True)
-        else:
-            raise FileNotFoundError(f"output directory does not exist: {directory}")
-
-    tasks = list()
-    for item in item_collection.items:
-        # TODO what happens if items share ids?
-        item_directory = directory_as_path / item.id
-        item_config = config.copy()
-        item_config.make_directory = True
-        item_config.file_name = None
-
-        # TODO we should share clients among items
-        tasks.append(
-            asyncio.create_task(
-                download_item(
-                    item=item,
-                    directory=item_directory,
-                    config=item_config,
-                    queue=queue,
-                )
-            )
-        )
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    exceptions = dict()
-    for result in results:
-        if isinstance(result, DownloadError):
-            exceptions.update(result.exceptions)
-        elif isinstance(result, Exception):
-            raise result
-    if exceptions:
-        raise DownloadError(exceptions)
-    item_collection.items = results
+    async with Downloads(config) as downloads:
+        for item in item_collection.items:
+            item.set_self_href(None)
+            root = Path(directory) / item.id
+            await downloads.add(item, root)
+        await downloads.download(queue)
     if config.file_name:
-        dest_href = str(directory_as_path / config.file_name)
+        dest_href = Path(directory) / config.file_name
         for item in item_collection.items:
             for asset in item.assets.values():
                 asset.href = pystac.utils.make_relative_href(
-                    asset.href, dest_href, start_is_dir=False
+                    asset.href, str(dest_href), start_is_dir=False
                 )
-        item_collection.save_object(dest_href=dest_href)
+        item_collection.save_object(dest_href=str(dest_href))
 
     return item_collection
-
-
-async def download_collection(
-    collection: Collection,
-    directory: PathLikeObject,
-    config: Optional[Config] = None,
-    queue: Optional[AnyQueue] = None,
-) -> Collection:
-    """Downloads a collection to the local filesystem.
-
-    Does not download the collection's items' assets -- use
-    :py:func:`download_item_collection` to download multiple items.
-
-    Args:
-        collection: A pystac collection
-        directory: The destination directory
-        config: The download configuration
-        queue: An optional queue to use for progress reporting
-
-    Returns:
-        Collection: The colleciton, with updated asset hrefs
-
-    Raises:
-        CantIncludeAndExclude: Raised if both include and exclude are not None.
-    """
-    return await _download(collection, directory, config or Config(), queue=queue)
-
-
-def guess_client_class(asset: Asset, config: Config) -> Type[Client]:
-    """Guess which client should be used to download the given asset.
-
-    If the configuration has ``alternate_assets``, these will be used instead of
-    the asset's href, if present. The asset's href will be updated with the href picked.
-
-    Args:
-        asset: The asset
-        config: A download configuration
-
-    Returns:
-        Client: The most appropriate client class for the href, maybe.
-    """
-    alternate = asset.extra_fields.get("alternate")
-    if not isinstance(alternate, dict):
-        alternate = None
-    if alternate and config.alternate_assets:
-        for alternate_asset in config.alternate_assets:
-            if alternate_asset in alternate:
-                try:
-                    href = alternate[alternate_asset]["href"]
-                    asset.href = href
-                    return guess_client_class_from_href(href)
-                except KeyError:
-                    raise ValueError(
-                        "invalid alternate asset definition (missing href): "
-                        f"{alternate}"
-                    )
-    return guess_client_class_from_href(asset.href)
-
-
-def guess_client_class_from_href(href: str) -> Type[Client]:
-    """Guess the client class from an href.
-
-    Args:
-        href: An href
-
-    Returns:
-        A client class type.
-    """
-    url = URL(href)
-    if not url.host:
-        return FilesystemClient
-    elif url.scheme == "s3":
-        return S3Client
-    elif url.host.endswith("blob.core.windows.net"):
-        return PlanetaryComputerClient
-    elif url.scheme == "http" or url.scheme == "https":
-        return HttpClient
-    else:
-        raise ValueError(f"could not guess client class for href: {href}")
 
 
 _T = TypeVar("_T", Collection, Item)
 
 
-async def _download(
+async def _download_stac_object(
     stac_object: _T,
     directory: PathLikeObject,
     config: Config,
     queue: Optional[AnyQueue],
 ) -> _T:
-    config.validate()
-
-    if not stac_object.assets:
-        raise ValueError(
-            f"no assets to download for STAC object with id '{stac_object.id}"
-        )
-    else:
-        # Will fail if the stac object doesn't have a self href and there's
-        # relative asset hrefs
-        stac_object = _make_asset_hrefs_absolute(stac_object)
-
-    directory_as_path = Path(directory)
-    if not directory_as_path.exists():
-        if config.make_directory:
-            directory_as_path.mkdir(parents=True)
-        else:
-            raise FileNotFoundError(f"output directory does not exist: {directory}")
+    links = list()
+    for link in stac_object.links:
+        absolute_href = link.get_absolute_href()
+        if absolute_href:
+            link.target = absolute_href
+            links.append(link)
+    stac_object.links = links
+    # Will fail if the stac object doesn't have a self href and there's
+    # relative asset hrefs
+    stac_object = _make_asset_hrefs_absolute(stac_object)
 
     if config.file_name:
-        item_path = directory_as_path / config.file_name
+        item_path = Path(directory) / config.file_name
         stac_object.set_self_href(str(item_path))
     else:
         item_path = None
         stac_object.set_self_href(item_path)
 
-    file_names: Set[str] = set()
-    assets: Dict[str, Tuple[Asset, Path]] = dict()
-    for key, asset in (
-        (k, a)
-        for k, a in stac_object.assets.items()
-        if (not config.include or k in config.include)
-        and (not config.exclude or k not in config.exclude)
-    ):
-        if config.asset_file_name_strategy == FileNameStrategy.FILE_NAME:
-            file_name = os.path.basename(URL(asset.href).path)
-        elif config.asset_file_name_strategy == FileNameStrategy.KEY:
-            file_name = key + Path(asset.href).suffix
+    async with Downloads(config) as downloads:
+        await downloads.add(stac_object, Path(directory))
+        await downloads.download(queue)
 
-        if file_name in file_names:
-            raise AssetOverwriteError(list(file_names))
-        else:
-            file_names.add(file_name)
+    self_href = stac_object.get_self_href()
+    if self_href:
+        _make_asset_hrefs_relative(stac_object)
+        d = stac_object.to_dict(include_self_link=True, transform_hrefs=False)
+        with open(self_href, "w") as f:
+            json.dump(d, f)
 
-        path = directory_as_path / file_name
-        assets[key] = (asset, path)
+    return stac_object
 
-    tasks = dict()
-    clients: Dict[Type[Client], Client] = dict()
-    for key, (asset, path) in assets.items():
-        client_class = guess_client_class(asset, config)
-        if client_class in clients:
-            client = clients[client_class]
-        else:
-            client = await client_class.from_config(config)
-            clients[client_class] = client
-        cloned_asset = asset.clone()
-        cloned_asset.set_owner(stac_object)
-        tasks[key] = asyncio.create_task(
-            client.download_asset(
-                key, cloned_asset, path, clean=config.clean, queue=queue
-            )
-        )
-        if stac_object.get_self_href():
-            stac_object.assets[key].href = pystac.utils.make_relative_href(
-                str(path), str(item_path)
-            )
-        else:
-            stac_object.assets[key].href = str(path.absolute())
 
-    # TODO support fast failing
-    exceptions = dict()
-    for key, task in tasks.items():
-        try:
-            _ = await task
-        except Exception as exception:
-            if config.warn:
-                warnings.warn(str(exception), DownloadWarning)
-                del stac_object.assets[key]
-            else:
-                exceptions[key] = exception
-
-    for client in clients.values():
-        await client.close()
-
-    if exceptions:
-        raise DownloadError(exceptions)
-
-    if stac_object.get_self_href():
-        stac_object.save_object(include_self_link=True)
-
+def _make_asset_hrefs_relative(stac_object: _T) -> _T:
+    # Copied from
+    # https://github.com/stac-utils/pystac/blob/381cf89fc25c15142fb5a187d905e22681de42a2/pystac/item.py#L284C5-L298C20
+    # until a fix for https://github.com/stac-utils/pystac/issues/1199 is
+    # released.
+    self_href = stac_object.get_self_href()
+    for asset in stac_object.assets.values():
+        if pystac.utils.is_absolute_href(asset.href):
+            if self_href is None:
+                raise STACError(
+                    "Cannot make asset HREFs relative " "if no self_href is set."
+                )
+            asset.href = pystac.utils.make_relative_href(asset.href, self_href)
     return stac_object
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -65,7 +65,7 @@ async def test_item_download_404_warn(tmp_path: Path, item: Item) -> None:
 
 
 async def test_item_download_no_directory(tmp_path: Path, item: Item) -> None:
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(DownloadError):
         await stac_asset.download_item(
             item, tmp_path / "doesnt-exist", Config(make_directory=False)
         )


### PR DESCRIPTION
## Description

Now we use the same basic infrastructure for item collections and items. The same client will be used for multiple items.

Breaking because it removes the `guess*` function.

## Checklist

- [x] Add tests
- [x] Add docs
- [x] Update CHANGELOG
