### PR TITLE
Allow binary/octet-stream always

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Use multiple clients when downloading ([#46](https://github.com/stac-utils/stac-asset/pull/46))
 - `--alternate-assets` option to the CLI ([#46](https://github.com/stac-utils/stac-asset/pull/46))
-- Content-type checking ([#46](https://github.com/stac-utils/stac-asset/pull/46))
+- Content-type checking ([#46](https://github.com/stac-utils/stac-asset/pull/46), [#60](https://github.com/stac-utils/stac-asset/issues/60))
 - `Client.from_config` and `Client.close` ([#46](https://github.com/stac-utils/stac-asset/pull/46))
 - Retry configuration for S3 ([#47](https://github.com/stac-utils/stac-asset/pull/47))
 - `Collection` download ([#50](https://github.com/stac-utils/stac-asset/pull/50))

--- a/src/stac_asset/_download.py
+++ b/src/stac_asset/_download.py
@@ -185,7 +185,6 @@ def guess_client_class(asset: Asset, config: Config) -> Type[Client]:
             if alternate_asset in alternate:
                 try:
                     href = alternate[alternate_asset]["href"]
-                    asset.extra_fields["alternate"]["original"] = {"href": href}
                     asset.href = href
                     return guess_client_class_from_href(href)
                 except KeyError:

--- a/src/stac_asset/validate.py
+++ b/src/stac_asset/validate.py
@@ -3,6 +3,7 @@ from .errors import ContentTypeError
 ALLOWABLE_PAIRS = [
     ("image/tiff", "image/tiff; application=geotiff; profile=cloud-optimized")
 ]
+IGNORED_CONTENT_TYPES = ["binary/octet-stream", "application/octet-stream"]
 
 
 def content_type(actual: str, expected: str) -> None:
@@ -20,6 +21,7 @@ def content_type(actual: str, expected: str) -> None:
     """
     if (
         actual != expected
+        and actual not in IGNORED_CONTENT_TYPES
         and (actual, expected) not in ALLOWABLE_PAIRS
         and (expected, actual) not in ALLOWABLE_PAIRS
     ):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -12,3 +12,5 @@ def test_content_type() -> None:
     validate.content_type(
         "image/tiff; application=geotiff; profile=cloud-optimized", "image/tiff"
     )
+    validate.content_type("binary/octet-stream", "doesn't matter")
+    validate.content_type("application/octet-stream", "doesn't matter")


### PR DESCRIPTION
## Related issues and pull requests

- Closes #60 

## Description

Always allow `octet-stream` results.

## Checklist

- [x] Add tests
- [ ] Add docs
- [x] Update CHANGELOG
