### PR TITLE
Add fast fails, split warn and error strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `Client.from_config` and `Client.close` ([#46](https://github.com/stac-utils/stac-asset/pull/46))
 - Retry configuration for S3 ([#47](https://github.com/stac-utils/stac-asset/pull/47))
 - `Collection` download ([#50](https://github.com/stac-utils/stac-asset/pull/50))
-- Progress reporting ([#55](https://github.com/stac-utils/stac-asset/pull/55))
-- `DownloadStrategy` ([#64](https://github.com/stac-utils/stac-asset/pull/64))
+- Progress reporting ([#55](https://github.com/stac-utils/stac-asset/pull/55), [#69](https://github.com/stac-utils/stac-asset/pull/69))
+- `ErrorStrategy` ([#69](https://github.com/stac-utils/stac-asset/pull/69))
+- `fail_fast` ([#69](https://github.com/stac-utils/stac-asset/pull/69))
 
 ### Changed
 
 - Use `Config` instead of standalone arguments ([#45](https://github.com/stac-utils/stac-asset/pull/45), [#67](https://github.com/stac-utils/stac-asset/pull/67))
-- s/CantIncludeAndExclude/CannotIncludeAndExclude/ ([#45](https://github.com/stac-utils/stac-asset/pull/45))
 - Re-use the same client for an entire item collection ([#59](https://github.com/stac-utils/stac-asset/pull/59))
 
 ### Removed

--- a/src/stac_asset/__init__.py
+++ b/src/stac_asset/__init__.py
@@ -29,7 +29,7 @@ from .filesystem_client import FilesystemClient
 from .http_client import HttpClient
 from .planetary_computer_client import PlanetaryComputerClient
 from .s3_client import S3Client
-from .strategy import DownloadStrategy, FileNameStrategy
+from .strategy import ErrorStrategy, FileNameStrategy
 
 __all__ = [
     "DownloadWarning",
@@ -39,7 +39,7 @@ __all__ = [
     "Config",
     "ContentTypeError",
     "DownloadError",
-    "DownloadStrategy",
+    "ErrorStrategy",
     "EarthdataClient",
     "FileNameStrategy",
     "FilesystemClient",

--- a/src/stac_asset/__init__.py
+++ b/src/stac_asset/__init__.py
@@ -20,7 +20,7 @@ from .config import Config
 from .earthdata_client import EarthdataClient
 from .errors import (
     AssetOverwriteError,
-    CannotIncludeAndExclude,
+    ConfigError,
     ContentTypeError,
     DownloadError,
     DownloadWarning,
@@ -31,16 +31,17 @@ from .planetary_computer_client import PlanetaryComputerClient
 from .s3_client import S3Client
 from .strategy import ErrorStrategy, FileNameStrategy
 
+# Keep this list sorted
 __all__ = [
-    "DownloadWarning",
     "AssetOverwriteError",
-    "CannotIncludeAndExclude",
     "Client",
     "Config",
+    "ConfigError",
     "ContentTypeError",
     "DownloadError",
-    "ErrorStrategy",
+    "DownloadWarning",
     "EarthdataClient",
+    "ErrorStrategy",
     "FileNameStrategy",
     "FilesystemClient",
     "HttpClient",

--- a/src/stac_asset/_cli.py
+++ b/src/stac_asset/_cli.py
@@ -109,6 +109,14 @@ def cli() -> None:
     show_default=True,
 )
 @click.option(
+    "--fail-fast",
+    help="Fail immediately on download error, instead of waiting until all are "
+    "complete. Mutually exclusive with --warn",
+    default=False,
+    is_flag=True,
+    show_default=True,
+)
+@click.option(
     "--overwrite",
     help="Overwrite existing files if they exist on the filesystem",
     default=False,
@@ -129,6 +137,7 @@ def download(
     s3_max_attempts: int,
     warn: bool,
     keep: bool,
+    fail_fast: bool,
     overwrite: bool,
 ) -> None:
     """Download STAC assets from an item or item collection.
@@ -164,6 +173,7 @@ def download(
             s3_max_attempts,
             warn=warn,
             keep=keep,
+            fail_fast=fail_fast,
             overwrite=overwrite,
         )
     )
@@ -182,6 +192,7 @@ async def download_async(
     s3_max_attempts: int,
     warn: bool,
     keep: bool,
+    fail_fast: bool,
     overwrite: bool,
 ) -> None:
     config = Config(
@@ -193,6 +204,7 @@ async def download_async(
         s3_max_attempts=s3_max_attempts,
         error_strategy=ErrorStrategy.KEEP if keep else ErrorStrategy.DELETE,
         warn=warn,
+        fail_fast=fail_fast,
         overwrite=overwrite,
     )
 

--- a/src/stac_asset/config.py
+++ b/src/stac_asset/config.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 
 from .errors import CannotIncludeAndExclude
-from .strategy import DownloadStrategy, FileNameStrategy
+from .strategy import ErrorStrategy, FileNameStrategy
 
 DEFAULT_S3_REGION_NAME = "us-west-2"
 DEFAULT_S3_RETRY_MODE = "adaptive"
@@ -19,10 +19,13 @@ class Config:
     alternate_assets: List[str] = field(default_factory=list)
     """Alternate asset keys to prefer, if available."""
 
-    asset_file_name_strategy: FileNameStrategy = FileNameStrategy.FILE_NAME
+    file_name_strategy: FileNameStrategy = FileNameStrategy.FILE_NAME
     """The file name strategy to use when downloading assets."""
 
-    download_strategy: DownloadStrategy = DownloadStrategy.ERROR
+    warn: bool = False
+    """If an error occurs during download, warn instead of raising the error."""
+
+    error_strategy: ErrorStrategy = ErrorStrategy.DELETE
     """The strategy to use when errors occur during download."""
 
     exclude: List[str] = field(default_factory=list)

--- a/src/stac_asset/errors.py
+++ b/src/stac_asset/errors.py
@@ -18,18 +18,8 @@ class DownloadWarning(Warning):
     """
 
 
-class CannotIncludeAndExclude(Exception):
-    """Raised if both include and exclude are passed to download."""
-
-    def __init__(
-        self, include: List[str], exclude: List[str], *args: Any, **kwargs: Any
-    ) -> None:
-        super().__init__(
-            "can't use include and exclude in the same download call: "
-            f"include={include}, exclude={exclude}",
-            *args,
-            **kwargs,
-        )
+class ConfigError(Exception):
+    """Raised if the configuration is not valid."""
 
 
 class ContentTypeError(Exception):

--- a/src/stac_asset/filesystem_client.py
+++ b/src/stac_asset/filesystem_client.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import os.path
 from asyncio import Queue
 from types import TracebackType
-from typing import Any, AsyncIterator, Optional, Type
+from typing import AsyncIterator, Optional, Type
 
 import aiofiles
 from yarl import URL
 
 from .client import Client
-from .messages import OpenUrl
+from .messages import Message, OpenUrl
 
 
 class FilesystemClient(Client):
@@ -22,7 +22,7 @@ class FilesystemClient(Client):
         self,
         url: URL,
         content_type: Optional[str] = None,
-        queue: Optional[Queue[Any]] = None,
+        messages: Optional[Queue[Message]] = None,
     ) -> AsyncIterator[bytes]:
         """Iterates over data from a local url.
 
@@ -30,7 +30,7 @@ class FilesystemClient(Client):
             url: The url to read bytes from
             content_type: The expected content type. Ignored by this client,
                 because filesystems don't have content types.
-            queue: An optional queue to use for progress reporting
+            messages: An optional queue to use for progress reporting
 
         Yields:
             AsyncIterator[bytes]: An iterator over the file's bytes.
@@ -44,8 +44,8 @@ class FilesystemClient(Client):
                 "cannot read a file with the filesystem client if it has a url scheme: "
                 + str(url)
             )
-        if queue:
-            await queue.put(OpenUrl(size=os.path.getsize(url.path), url=url))
+        if messages:
+            await messages.put(OpenUrl(size=os.path.getsize(url.path), url=url))
         async with aiofiles.open(url.path, "rb") as f:
             async for chunk in f:
                 yield chunk

--- a/src/stac_asset/http_client.py
+++ b/src/stac_asset/http_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from asyncio import Queue
 from types import TracebackType
-from typing import Any, AsyncIterator, Optional, Type, TypeVar
+from typing import AsyncIterator, Optional, Type, TypeVar
 
 from aiohttp import ClientSession
 from yarl import URL
@@ -10,7 +10,7 @@ from yarl import URL
 from . import validate
 from .client import Client
 from .config import Config
-from .messages import OpenUrl
+from .messages import Message, OpenUrl
 
 T = TypeVar("T", bound="HttpClient")
 
@@ -41,14 +41,14 @@ class HttpClient(Client):
         self,
         url: URL,
         content_type: Optional[str] = None,
-        queue: Optional[Queue[Any]] = None,
+        messages: Optional[Queue[Message]] = None,
     ) -> AsyncIterator[bytes]:
         """Opens a url with this client's session and iterates over its bytes.
 
         Args:
             url: The url to open
             content_type: The expected content type
-            queue: An optional queue to use for progress reporting
+            messages: An optional queue to use for progress reporting
 
         Yields:
             AsyncIterator[bytes]: An iterator over the file's bytes
@@ -62,8 +62,8 @@ class HttpClient(Client):
                 validate.content_type(
                     actual=response.content_type, expected=content_type
                 )
-            if queue:
-                await queue.put(OpenUrl(url=url, size=response.content_length))
+            if messages:
+                await messages.put(OpenUrl(url=url, size=response.content_length))
             async for chunk, _ in response.content.iter_chunks():
                 yield chunk
 

--- a/src/stac_asset/messages.py
+++ b/src/stac_asset/messages.py
@@ -6,7 +6,12 @@ from yarl import URL
 
 
 @dataclass
-class StartAssetDownload:
+class Message:
+    """A message about downloading."""
+
+
+@dataclass
+class StartAssetDownload(Message):
     """Sent when an asset starts downloading."""
 
     key: str
@@ -23,7 +28,7 @@ class StartAssetDownload:
 
 
 @dataclass
-class ErrorAssetDownload:
+class ErrorAssetDownload(Message):
     """Sent when an asset starts downloading."""
 
     key: str
@@ -37,7 +42,7 @@ class ErrorAssetDownload:
 
 
 @dataclass
-class FinishAssetDownload:
+class FinishAssetDownload(Message):
     """Sent when an asset finishes downloading."""
 
     key: str
@@ -51,7 +56,7 @@ class FinishAssetDownload:
 
 
 @dataclass
-class WriteChunk:
+class WriteChunk(Message):
     """Sent when a chunk is written to disk."""
 
     href: str
@@ -65,7 +70,7 @@ class WriteChunk:
 
 
 @dataclass
-class OpenUrl:
+class OpenUrl(Message):
     """Sent when a url is first opened."""
 
     url: URL

--- a/src/stac_asset/planetary_computer_client.py
+++ b/src/stac_asset/planetary_computer_client.py
@@ -70,7 +70,7 @@ class PlanetaryComputerClient(HttpClient):
         self,
         url: URL,
         content_type: Optional[str] = None,
-        queue: Optional[Queue[Any]] = None,
+        messages: Optional[Queue[Any]] = None,
     ) -> AsyncIterator[bytes]:
         """Opens a url and iterates over its bytes.
 
@@ -88,7 +88,7 @@ class PlanetaryComputerClient(HttpClient):
         Args:
             url: The url to open
             content_type: The expected content type
-            queue: An optional queue to use for progress reporting
+            messages: An optional queue to use for progress reporting
 
         Yields:
             AsyncIterator[bytes]: An iterator over the file's bytes
@@ -101,7 +101,7 @@ class PlanetaryComputerClient(HttpClient):
         ):
             url = await self._sign(url)
         async for chunk in super().open_url(
-            url, content_type=content_type, queue=queue
+            url, content_type=content_type, messages=messages
         ):
             yield chunk
 

--- a/src/stac_asset/s3_client.py
+++ b/src/stac_asset/s3_client.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from asyncio import Queue
 from types import TracebackType
-from typing import Any, AsyncIterator, Optional, Type
+from typing import AsyncIterator, Optional, Type
 
 import aiobotocore.session
 import botocore.config
@@ -18,7 +18,7 @@ from .config import (
     DEFAULT_S3_RETRY_MODE,
     Config,
 )
-from .messages import OpenUrl
+from .messages import Message, OpenUrl
 
 
 class S3Client(Client):
@@ -74,14 +74,14 @@ class S3Client(Client):
         self,
         url: URL,
         content_type: Optional[str] = None,
-        queue: Optional[Queue[Any]] = None,
+        messages: Optional[Queue[Message]] = None,
     ) -> AsyncIterator[bytes]:
         """Opens an s3 url and iterates over its bytes.
 
         Args:
             url: The url to open
             content_type: The expected content type
-            queue: An optional queue to use for progress reporting
+            messages: An optional queue to use for progress reporting
 
         Yields:
             AsyncIterator[bytes]: An iterator over the file's bytes
@@ -113,8 +113,8 @@ class S3Client(Client):
             response = await client.get_object(**params)
             if content_type:
                 validate.content_type(response["ContentType"], content_type)
-            if queue:
-                await queue.put(OpenUrl(url=url, size=response["ContentLength"]))
+            if messages:
+                await messages.put(OpenUrl(url=url, size=response["ContentLength"]))
             async for chunk in response["Body"]:
                 yield chunk
 

--- a/src/stac_asset/strategy.py
+++ b/src/stac_asset/strategy.py
@@ -15,14 +15,11 @@ class FileNameStrategy(Enum):
     """Save the asset with its key as its file name."""
 
 
-class DownloadStrategy(Enum):
+class ErrorStrategy(Enum):
     """Strategy to use when encountering errors during download."""
 
-    ERROR = auto()
-    """Throw an error if an asset cannot be downloaded."""
-
     KEEP = auto()
-    """Warn, but keep the asset on the item."""
+    """Keep the asset on the item with its original href."""
 
     DELETE = auto()
-    """Warn, but delete the asset from the item."""
+    """Delete the asset from the item."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 import pytest
-from stac_asset import CannotIncludeAndExclude, Config
+from stac_asset import Config, ConfigError
 
 
 def test_validate_default() -> None:
@@ -9,5 +9,11 @@ def test_validate_default() -> None:
 
 def test_validate_include_and_exclude() -> None:
     config = Config(include=["foo"], exclude=["bar"])
-    with pytest.raises(CannotIncludeAndExclude):
+    with pytest.raises(ConfigError):
+        config.validate()
+
+
+def test_warn_and_fail_fast() -> None:
+    config = Config(warn=True, fail_fast=True)
+    with pytest.raises(ConfigError):
         config.validate()


### PR DESCRIPTION
## Description

- Adds a `fail_fast` option to the config
- Splits out `warn` from `error_strategy`
- Adds a `Message` superclass

## Checklist

- [x] Add tests
- [x] Add docs
- [x] Update CHANGELOG
