### PR TITLE
Use absolute paths for item collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Use absolute paths for item collection downloads ([#96](https://github.com/stac-utils/stac-asset/pull/96))
+
 ## [0.2.0] - 2023-08-23
 
 ### Added

--- a/src/stac_asset/_functions.py
+++ b/src/stac_asset/_functions.py
@@ -305,11 +305,6 @@ async def download_item_collection(
         await downloads.download(messages)
     if file_name:
         dest_href = Path(directory) / file_name
-        for item in item_collection.items:
-            for asset in item.assets.values():
-                asset.href = pystac.utils.make_relative_href(
-                    asset.href, str(dest_href), start_is_dir=False
-                )
         item_collection.save_object(dest_href=str(dest_href))
 
     return item_collection

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -102,9 +102,8 @@ async def test_download_item_collection_with_file_name(
         item_collection, tmp_path, file_name="item-collection.json"
     )
     item_collection = ItemCollection.from_file(str(tmp_path / "item-collection.json"))
-    assert (
-        item_collection.items[0].assets["data"].href
-        == "./test-item/20201211_223832_CS2.jpg"
+    assert item_collection.items[0].assets["data"].href == str(
+        tmp_path / "test-item/20201211_223832_CS2.jpg"
     )
 
 


### PR DESCRIPTION
## Description

PySTAC doesn't set self href when reading from file, so it's awkward to use relative paths. Plus, most folks expect item collections to have absolute b/c they're from searches or whatever.

## Checklist

- [x] Add tests
- [ ] Add docs
- [x] Update CHANGELOG
