### PR TITLE
Document how to allow blocking requests when asyncio is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ item = pystac.read_file(href)
 item = stac_asset.blocking.download_item(item, ".")
 ```
 
+Note that the above will not work in some environments like Jupyter notebooks which already have their own `asyncio` loop running.
+To get around this, you can use [`nest_asyncio`](https://pypi.org/project/nest-asyncio/).
+Simply run the following before using any functions from `stac_asset.blocking`.
+
+```python
+import nest_asyncio
+nest_asyncio.apply()
+```
+
 ### CLI
 
 To download an item using the command line:


### PR DESCRIPTION
## Related issues and pull requests

- Closes #109 

## Description

This PR adds a note about how to make `stac_asset.blocking` functions work inside a notebook.

Example usages of the workaround:
- https://colab.research.google.com/drive/1Gofatz0sUIhbBj64K15Dkj-4raejKBF2#scrollTo=grf6rsueMSi4
- https://github.com/stac-utils/stac-task/pull/42/files#diff-0ed2cf4aaeba2d2a23f6230accc39f7aedcf80e0feea2a89639c7633282f293aR148-R156

## Checklist

- [ ] Add tests
- [x] Add docs
- [ ] Update CHANGELOG
