### PR TITLE
feat: add stream_href method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `open_href` ([#123](https://github.com/stac-utils/stac-asset/pull/123))
+
 ## [0.2.3] - 2023-10-20
 
 ### Added

--- a/src/stac_asset/__init__.py
+++ b/src/stac_asset/__init__.py
@@ -21,6 +21,7 @@ from ._functions import (
     download_collection,
     download_item,
     download_item_collection,
+    open_href,
     read_href,
 )
 from .client import Client
@@ -63,5 +64,6 @@ __all__ = [
     "download_collection",
     "download_item",
     "download_item_collection",
+    "open_href",
     "read_href",
 ]

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -211,6 +211,13 @@ async def test_assert_asset_exists(item: Item) -> None:
         await stac_asset.assert_asset_exists(Asset(href="not-a-file"))
 
 
+async def test_open_href(data_path: Path) -> None:
+    text = b""
+    async for chunk in stac_asset.open_href(str(data_path / "item.json")):
+        text += chunk
+    Item.from_dict(json.loads(text))
+
+
 async def test_read_href(data_path: Path) -> None:
     text = await stac_asset.read_href(str(data_path / "item.json"))
     Item.from_dict(json.loads(text))


### PR DESCRIPTION
## Related issues and pull requests

- n/a

## Description

I have a case where I am using `read_href`, but can significantly decrease memory usage if I use the chunks as they are downloaded rather than waiting for the the complete byte stream from `read_href`. Seeing that `read_href` is concatenating a stream, this change simply splits the chunked downloading from `read_href` into a new method `stream_href`, which `read_href` uses internally.

## Checklist

- [x] Add tests
- [x] Add docs
- [x] Update CHANGELOG
