### PR TITLE
Remove tokens from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: PyPI
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,11 +27,8 @@ jobs:
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/v')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Description

I set up trusted publishers in PyPI and test PyPI, so this _should_ work?
