### PR TITLE
create directory for writing item json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - `open_href` ([#123](https://github.com/stac-utils/stac-asset/pull/123))
 
+### Fixed
+
+- Directory for writing Item JSON is always created ([#152](https://github.com/stac-utils/stac-asset/pull/152))
+
 ## [0.2.3] - 2023-10-20
 
 ### Added

--- a/src/stac_asset/_functions.py
+++ b/src/stac_asset/_functions.py
@@ -238,6 +238,7 @@ async def download_item(
     if self_href:
         make_asset_hrefs_relative(item)
         d = item.to_dict(include_self_link=True, transform_hrefs=False)
+        os.makedirs(os.path.dirname(self_href), exist_ok=True)
         with open(self_href, "w") as f:
             json.dump(d, f)
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -74,6 +74,18 @@ async def test_download_missing_asset_delete(tmp_path: Path, item: Item) -> None
     assert "does-not-exist" not in item.assets
 
 
+async def test_download_nonexistent_asset(tmp_path: Path, item: Item) -> None:
+    # this previously had a bug where the code assumed the directory had
+    # been created by downloading the assets when trying to write the item json,
+    # but it hadn't, so a failure occurred
+    await stac_asset.download_item(
+        item,
+        tmp_path / "dir-that-doesnt-exist",
+        file_name="item.json",
+        config=Config(include=["non-existent-asset"]),
+    )
+
+
 async def test_download_missing_asset_fail_fast(tmp_path: Path, item: Item) -> None:
     item.assets["does-not-exist"] = Asset("not-a-file.md5")
     with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
## Related issues and pull requests

- n/a

## Description

While testing stac-task, I observed that the test that requested a non-existent asset name to be downloaded (or, I believe, and case where no assets are downloaded) resulted in an error writing the item.json if the working directory didn't already exist. This PR makes sure that directory does exist before writing the json.

## Checklist

- [X] Add tests
- [X] Add docs
- [X] Update CHANGELOG
