### PR TITLE
Exclude bad matrix configs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,13 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+        exclude:  # macos-latest is arm64, which doesn't have these pythons
+          - os: macos-latest
+            python-version: "3.8"
+          - os: macos-latest
+            python-version: "3.9"
+          - os: macos-latest
+            python-version: "3.10"
       fail-fast: true
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
`macos-latest` is arm64, and doesn't have older Pythons.