### PR TITLE
deprecate python 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,6 @@ jobs:
           - macos-latest
         exclude:  # macos-latest is arm64, which doesn't have these pythons
           - os: macos-latest
-            python-version: "3.8"
-          - os: macos-latest
             python-version: "3.9"
           - os: macos-latest
             python-version: "3.10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Removed
 
-- Python 3.8 is no longer supported
+- Python 3.8 is no longer supported ([#154](https://github.com/stac-utils/stac-asset/pull/154))
 
 ### Fixed
 
 - Directory for writing Item JSON is always created ([#152](https://github.com/stac-utils/stac-asset/pull/152))
-
 
 ## [0.2.4] - 2024-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Removed
+
+- Python 3.8 is no longer supported
+
+### Fixed
+
+- Directory for writing Item JSON is always created ([#152](https://github.com/stac-utils/stac-asset/pull/152))
+
+
 ## [0.2.4] - 2024-04-02
 
 ### Added
 
 - `open_href` ([#123](https://github.com/stac-utils/stac-asset/pull/123))
 
-### Fixed
-
-- Directory for writing Item JSON is always created ([#152](https://github.com/stac-utils/stac-asset/pull/152))
 
 ## [0.2.3] - 2023-10-20
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ keywords = ["stac", "async"]
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -16,7 +15,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
 ]
 license = { text = "Apache-2.0" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "aiofiles>=23.1.0",
     "aiobotocore>=2.5.0",

--- a/src/stac_asset/_functions.py
+++ b/src/stac_asset/_functions.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import os.path
 import warnings
-from asyncio import Queue, Task
+from asyncio import Task
 from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
@@ -27,7 +27,6 @@ from .errors import AssetOverwriteError, DownloadError, DownloadWarning
 from .messages import (
     ErrorAssetDownload,
     FinishAssetDownload,
-    Message,
     SkipAssetDownload,
     StartAssetDownload,
 )
@@ -341,7 +340,7 @@ async def download_asset(
     asset: Asset,
     path: Path,
     config: Config,
-    messages: Optional[Queue[Message]] = None,
+    messages: Optional[MessageQueue] = None,
     clients: Optional[Clients] = None,
 ) -> Asset:
     """Downloads an asset.

--- a/src/stac_asset/client.py
+++ b/src/stac_asset/client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from asyncio import Lock, Queue, QueueFull
+from asyncio import Lock, QueueFull
 from pathlib import Path
 from types import TracebackType
 from typing import AsyncIterator, Dict, List, Optional, Type, TypeVar
@@ -11,10 +11,9 @@ from yarl import URL
 
 from .config import Config
 from .messages import (
-    Message,
     WriteChunk,
 )
-from .types import PathLikeObject
+from .types import MessageQueue, PathLikeObject
 
 T = TypeVar("T", bound="Client")
 
@@ -41,7 +40,7 @@ class Client(ABC):
         self,
         url: URL,
         content_type: Optional[str] = None,
-        messages: Optional[Queue[Message]] = None,
+        messages: Optional[MessageQueue] = None,
     ) -> AsyncIterator[bytes]:
         """Opens a url and yields an iterator over its bytes.
 
@@ -64,7 +63,7 @@ class Client(ABC):
         self,
         href: str,
         content_type: Optional[str] = None,
-        messages: Optional[Queue[Message]] = None,
+        messages: Optional[MessageQueue] = None,
     ) -> AsyncIterator[bytes]:
         """Opens a href and yields an iterator over its bytes.
 
@@ -87,7 +86,7 @@ class Client(ABC):
         path: PathLikeObject,
         clean: bool = True,
         content_type: Optional[str] = None,
-        messages: Optional[Queue[Message]] = None,
+        messages: Optional[MessageQueue] = None,
     ) -> None:
         """Downloads a file to the local filesystem.
 

--- a/src/stac_asset/filesystem_client.py
+++ b/src/stac_asset/filesystem_client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os.path
-from asyncio import Queue
 from types import TracebackType
 from typing import AsyncIterator, Optional, Type
 
@@ -9,7 +8,8 @@ import aiofiles
 from yarl import URL
 
 from .client import Client
-from .messages import Message, OpenUrl
+from .messages import OpenUrl
+from .types import MessageQueue
 
 
 class FilesystemClient(Client):
@@ -22,7 +22,7 @@ class FilesystemClient(Client):
         self,
         url: URL,
         content_type: Optional[str] = None,
-        messages: Optional[Queue[Message]] = None,
+        messages: Optional[MessageQueue] = None,
     ) -> AsyncIterator[bytes]:
         """Iterates over data from a local url.
 

--- a/src/stac_asset/http_client.py
+++ b/src/stac_asset/http_client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from asyncio import Queue
 from types import TracebackType
 from typing import AsyncIterator, Optional, Type, TypeVar
 
@@ -10,7 +9,8 @@ from yarl import URL
 from . import validate
 from .client import Client
 from .config import Config
-from .messages import Message, OpenUrl
+from .messages import OpenUrl
+from .types import MessageQueue
 
 T = TypeVar("T", bound="HttpClient")
 
@@ -48,7 +48,7 @@ class HttpClient(Client):
         self,
         url: URL,
         content_type: Optional[str] = None,
-        messages: Optional[Queue[Message]] = None,
+        messages: Optional[MessageQueue] = None,
     ) -> AsyncIterator[bytes]:
         """Opens a url with this client's session and iterates over its bytes.
 

--- a/src/stac_asset/s3_client.py
+++ b/src/stac_asset/s3_client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from asyncio import Queue
 from types import TracebackType
 from typing import Any, AsyncIterator, Dict, Optional, Type
 
@@ -18,7 +17,8 @@ from .config import (
     DEFAULT_S3_RETRY_MODE,
     Config,
 )
-from .messages import Message, OpenUrl
+from .messages import OpenUrl
+from .types import MessageQueue
 
 
 class S3Client(Client):
@@ -86,7 +86,7 @@ class S3Client(Client):
         self,
         url: URL,
         content_type: Optional[str] = None,
-        messages: Optional[Queue[Message]] = None,
+        messages: Optional[MessageQueue] = None,
     ) -> AsyncIterator[bytes]:
         """Opens an s3 url and iterates over its bytes.
 

--- a/src/stac_asset/types.py
+++ b/src/stac_asset/types.py
@@ -1,20 +1,12 @@
 from asyncio import Queue
 from os import PathLike
-from typing import TYPE_CHECKING, Union
+from typing import Any, Union
 
 from .messages import Message
 
-if TYPE_CHECKING:
-    from typing import Any
+MessageQueue = Queue[Message]
 
-    _PathLike = PathLike[Any]
-    # Needed until we drop Python 3.8
-    MessageQueue = Queue[Message]
-else:
-    _PathLike = PathLike
-    MessageQueue = Queue
-
-PathLikeObject = Union[_PathLike, str]
+PathLikeObject = Union[PathLike[Any], str]
 """An object representing a file system path, except we exclude `bytes` because
 `Path()` doesn't accept `bytes`.
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -15,9 +15,9 @@ from stac_asset import (
     DownloadWarning,
     ErrorStrategy,
     FileNameStrategy,
-    Message,
     S3Client,
 )
+from stac_asset.types import MessageQueue
 
 pytestmark = [
     pytest.mark.asyncio,
@@ -207,7 +207,7 @@ async def test_preconfigured_clients(tmp_path: Path, item: Item) -> None:
 
 
 async def test_queue(tmp_path: Path, item: Item) -> None:
-    messages: Queue[Message] = Queue()
+    messages: MessageQueue = Queue()
     item = await stac_asset.download_item(item, tmp_path, messages=messages)
     assert not messages.empty()
 


### PR DESCRIPTION
## Related issues and pull requests

- n/a

## Description

- Deprecate Python 3.8 support.
- Update some typing wrt not needing to support 3.8

## Checklist

- [X] Add tests
- [X] Add docs
- [X] Update CHANGELOG
