### PR TITLE
fix: limit number of concurrently opened files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Timeout configuration for `HttpClient` ([#163](https://github.com/stac-utils/stac-asset/pull/163))
 - **pytest-recording** and vcr marks to a couple tests ([#166](https://github.com/stac-utils/stac-asset/pull/166))
 
+### Fixed
+
+- Limit the number of concurrent downloads ([#167](https://github.com/stac-utils/stac-asset/pull/167))
+
 ## [0.3.1] - 2024-05-13
 
 ### Added

--- a/src/stac_asset/_functions.py
+++ b/src/stac_asset/_functions.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import os.path
 import warnings
-from asyncio import Semaphore, Task 
+from asyncio import Semaphore, Task
 from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
@@ -176,11 +176,11 @@ class Downloads:
         if exceptions:
             raise DownloadError(exceptions)
 
-    async def _download_with_release(self, download, messages):
+    async def _download_with_release(
+        self, download: Download, messages: Optional[MessageQueue]
+    ) -> Download | WrappedError:
         try:
             return await download.download(messages=messages)
-        except Exception as e:
-            return WrappedError(download=download, error=e)
         finally:
             self.semaphore.release()
 

--- a/src/stac_asset/_functions.py
+++ b/src/stac_asset/_functions.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import os.path
 import warnings
-from asyncio import Task
+from asyncio import Semaphore, Task 
 from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
@@ -74,7 +74,7 @@ class Downloads:
     clients: Clients
     config: Config
     downloads: List[Download]
-    semaphore: asyncio.Semaphore
+    semaphore: Semaphore
 
     def __init__(
         self,
@@ -86,7 +86,7 @@ class Downloads:
         self.config = config
         self.downloads = list()
         self.clients = Clients(config, clients)
-        self.semaphore = asyncio.Semaphore(max_concurrent_downloads)
+        self.semaphore = Semaphore(max_concurrent_downloads)
 
     async def add(
         self,

--- a/src/stac_asset/_functions.py
+++ b/src/stac_asset/_functions.py
@@ -80,7 +80,7 @@ class Downloads:
         self,
         config: Config,
         clients: Optional[List[Client]] = None,
-        max_concurrent_downloads: int = 1024,
+        max_concurrent_downloads: int = 500,
     ) -> None:
         config.validate()
         self.config = config


### PR DESCRIPTION
## Description

The Downloads class manages concurrent downloads using asynchronous tasks. However, due to operating system's limits, an _[Errno 24] Too many open files_ may occur, when many files are downloaded in parallel. Rather than launching an asynchronous task for every single download all at once, this PR introduces a semaphore to limit the number of downloads that can run in parallel. This prevents hitting the file descriptor limit.

## Checklist

- [ ] Add tests
- [ ] Add docs
- [ ] Update CHANGELOG
