### PR TITLE
Move attributes docs to __init__

### DIFF
--- a/src/stac_asset/http_client.py
+++ b/src/stac_asset/http_client.py
@@ -22,16 +22,6 @@ class HttpClient(Client):
     Configure the session to customize its behavior.
     """
 
-    check_content_type: bool
-    """If true, check the asset's content type against the response from the server.
-
-    See :py:func:`stac_asset.validate.content_type` for more information about
-    hte content type check.
-    """
-
-    session: ClientSession
-    """A atiohttp session that will be used for all requests."""
-
     @classmethod
     async def from_config(cls: Type[T], config: Config) -> T:
         """Creates the default http client with a vanilla session object."""
@@ -42,8 +32,16 @@ class HttpClient(Client):
 
     def __init__(self, session: ClientSession, check_content_type: bool = True) -> None:
         super().__init__()
-        self.session = session
-        self.check_content_type = check_content_type
+
+        self.session: ClientSession = session
+        """A aiohttp session that will be used for all requests."""
+
+        self.check_content_type: bool = check_content_type
+        """If true, check the asset's content type against the response from the server.
+
+        See :py:func:`stac_asset.validate.content_type` for more information about
+        the content type check.
+        """
 
     async def open_url(
         self,

--- a/src/stac_asset/planetary_computer_client.py
+++ b/src/stac_asset/planetary_computer_client.py
@@ -52,19 +52,17 @@ class PlanetaryComputerClient(HttpClient):
     thanks Tom Augspurger!
     """
 
-    _cache: Dict[URL, _Token]
-    _cache_lock: Lock
-    token_request_url: URL
-
     def __init__(
         self,
         session: ClientSession,
         sas_token_endpoint: str = DEFAULT_SAS_TOKEN_ENDPOINT,
     ) -> None:
         super().__init__(session)
-        self._cache = dict()
-        self._cache_lock = Lock()
-        self.sas_token_endpoint = URL(sas_token_endpoint)
+        self._cache: Dict[URL, _Token] = dict()
+        self._cache_lock: Lock = Lock()
+
+        self.sas_token_endpoint: URL = URL(sas_token_endpoint)
+        """The endpoint that will be used to fetch a SAS token for reading."""
 
     async def open_url(
         self,

--- a/src/stac_asset/s3_client.py
+++ b/src/stac_asset/s3_client.py
@@ -30,27 +30,6 @@ class S3Client(Client):
     for instructions.
     """
 
-    session: AioSession
-    """The session that will be used for all s3 requests."""
-
-    region_name: str
-    """The region that all clients will be rooted in."""
-
-    requester_pays: bool
-    """If True, enable access to `requester pays buckets
-    <https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html>`_."""
-
-    retry_mode: str
-    """The retry mode, one of "adaptive", "legacy", or "standard".
-
-    See `the boto3 docs
-    <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html>`_
-    for more information on the available modes.
-    """
-
-    max_attempts: int
-    """The maximum number of attempts."""
-
     @classmethod
     async def from_config(cls, config: Config) -> S3Client:
         """Creates an s3 client from a config.
@@ -76,11 +55,27 @@ class S3Client(Client):
         max_attempts: int = DEFAULT_S3_MAX_ATTEMPTS,
     ) -> None:
         super().__init__()
-        self.session = aiobotocore.session.get_session()
-        self.region_name = region_name
-        self.requester_pays = requester_pays
-        self.retry_mode = retry_mode
-        self.max_attempts = max_attempts
+
+        self.session: AioSession = aiobotocore.session.get_session()
+        """The session that will be used for all s3 requests."""
+
+        self.region_name: str = region_name
+        """The region that all clients will be rooted in."""
+
+        self.requester_pays: bool = requester_pays
+        """If True, enable access to `requester pays buckets
+        <https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html>`_."""
+
+        self.retry_mode: str = retry_mode
+        """The retry mode, one of "adaptive", "legacy", or "standard".
+
+        See `the boto3 docs
+        <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html>`_
+        for more information on the available modes.
+        """
+
+        self.max_attempts: int = max_attempts
+        """The maximum number of attempts."""
 
     async def open_url(
         self,


### PR DESCRIPTION
## Related issues and pull requests

- Closes #165 

## Description

I didn't understand **sphinx-autodoc** well enough...seems better to document inside the `__init__` method on assignment. cc @drnextgis. No tests or CHANGELOG needed.

## Checklist

- [x] Add docs

