### PR TITLE
Allow content types text/xml and application/xml to be used interchangeably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - `download_file` ([#122](https://github.com/stac-utils/stac-asset/pull/172))
+- content type validation rule for `text/xml` and `application/xml` ([#173](https://github.com/stac-utils/stac-asset/pull/173)) 
 
 ## [0.3.2] - 2024-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - `download_file` ([#122](https://github.com/stac-utils/stac-asset/pull/172))
-- content type validation rule for `text/xml` and `application/xml` ([#173](https://github.com/stac-utils/stac-asset/pull/173)) 
+- allow `text/xml` and `application/xml` to be used interchangeably ([#173](https://github.com/stac-utils/stac-asset/pull/173)) 
 
 ## [0.3.2] - 2024-05-20
 

--- a/src/stac_asset/validate.py
+++ b/src/stac_asset/validate.py
@@ -1,7 +1,8 @@
 from .errors import ContentTypeError
 
 ALLOWABLE_PAIRS = [
-    ("image/tiff", "image/tiff; application=geotiff; profile=cloud-optimized")
+    ("image/tiff", "image/tiff; application=geotiff; profile=cloud-optimized"),
+    ("text/xml", "application/xml"),
 ]
 IGNORED_CONTENT_TYPES = ["binary/octet-stream", "application/octet-stream"]
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -12,5 +12,7 @@ def test_content_type() -> None:
     validate.content_type(
         "image/tiff; application=geotiff; profile=cloud-optimized", "image/tiff"
     )
+    validate.content_type("text/xml", "application/xml")
+    validate.content_type("application/xml", "text/xml")
     validate.content_type("binary/octet-stream", "doesn't matter")
     validate.content_type("application/octet-stream", "doesn't matter")


### PR DESCRIPTION
Allow content types text/xml and application/xml to be used interchangeably

## Related issues and pull requests
N/A

## Description

The XML content types `text/xml` and `application/xml` are sometimes used interchangeably in different places. For example, the STAC metadata may reference one, but the web server for downloading may report the other one. Right now, such a scenario would cause an error when content type validation is enabled.

https://datatracker.ietf.org/doc/html/rfc2376#section-3

## Checklist

- [x] Add tests
- [ ] Add docs
- [x] Update CHANGELOG
