### PR TITLE
Expose all client attributes in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- More `HttpClient` attributes to `Config` ([#177](https://github.com/stac-utils/stac-asset/pull/177))
+
+### Removed
+
+- `EarthdataClient.login` ([#177](https://github.com/stac-utils/stac-asset/pull/177))
+- Default value for `HttpClient`'s `check_content_type` ([#177](https://github.com/stac-utils/stac-asset/pull/177))
+
 ## [0.3.3] - 2024-05-28
 
 ### Added

--- a/src/stac_asset/config.py
+++ b/src/stac_asset/config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from .errors import ConfigError
 from .strategy import ErrorStrategy, FileNameStrategy
@@ -62,6 +62,12 @@ class Config:
 
     http_client_timeout: Optional[float] = DEFAULT_HTTP_CLIENT_TIMEOUT
     """Total number of seconds for the whole request."""
+
+    http_check_content_type: bool = True
+    """If true, check the asset's content type against the response from the server."""
+
+    http_headers: Dict[str, str] = field(default_factory=dict)
+    """Extra headers to include in every http request."""
 
     earthdata_token: Optional[str] = None
     """A token for logging in to Earthdata."""

--- a/src/stac_asset/http_client.py
+++ b/src/stac_asset/http_client.py
@@ -27,10 +27,14 @@ class HttpClient(Client):
         """Creates the default http client with a vanilla session object."""
         # TODO add basic auth
         timeout = ClientTimeout(total=config.http_client_timeout)
-        session = ClientSession(timeout=timeout)
-        return cls(session)
+        session = ClientSession(timeout=timeout, headers=config.http_headers)
+        return cls(session, config.http_check_content_type)
 
-    def __init__(self, session: ClientSession, check_content_type: bool = True) -> None:
+    def __init__(
+        self,
+        session: ClientSession,
+        check_content_type: bool,
+    ) -> None:
         super().__init__()
 
         self.session: ClientSession = session

--- a/src/stac_asset/planetary_computer_client.py
+++ b/src/stac_asset/planetary_computer_client.py
@@ -55,9 +55,10 @@ class PlanetaryComputerClient(HttpClient):
     def __init__(
         self,
         session: ClientSession,
+        check_content_type: bool,
         sas_token_endpoint: str = DEFAULT_SAS_TOKEN_ENDPOINT,
     ) -> None:
-        super().__init__(session)
+        super().__init__(session, check_content_type)
         self._cache: Dict[URL, _Token] = dict()
         self._cache_lock: Lock = Lock()
 

--- a/tests/test_earthdata_client.py
+++ b/tests/test_earthdata_client.py
@@ -2,7 +2,7 @@ import os.path
 from pathlib import Path
 
 import pytest
-from stac_asset import EarthdataClient
+from stac_asset import Config, EarthdataClient
 
 pytestmark = [
     pytest.mark.skipif(
@@ -16,6 +16,6 @@ pytestmark = [
 
 async def test_download_href(tmp_path: Path) -> None:
     href = "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/MYD11A1.061/MYD11A1.A2023145.h14v17.061.2023146183035/MYD11A1.A2023145.h14v17.061.2023146183035.hdf"
-    async with await EarthdataClient.login() as client:
+    async with await EarthdataClient.from_config(Config()) as client:
         await client.download_href(href, tmp_path / "out.hdf")
         assert os.path.getsize(tmp_path / "out.hdf") == 197419


### PR DESCRIPTION
## Related issues and pull requests

- Closes #176

## Description

After playing around with some dynamic config, I didn't like how complex it made things. Instead, I'll just make sure to bubble up all client attributes to the top-level config.

This is a breaking change that requires a MAJOR version release.

Also:

- Removes `EarthdataClient.login`
- Makes `check_content_type` a non-optional param for `HttpClient.__init__`

## Checklist

- [x] Add tests
- [x] Add docs
- [x] Update CHANGELOG
