### PR TITLE
Add derived_from link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - More `HttpClient` attributes to `Config` ([#177](https://github.com/stac-utils/stac-asset/pull/177))
+- `derived_from` link ([#178](https://github.com/stac-utils/stac-asset/pull/178))
 
 ### Removed
 

--- a/src/stac_asset/_functions.py
+++ b/src/stac_asset/_functions.py
@@ -18,7 +18,7 @@ from typing import (
 )
 
 import pystac.utils
-from pystac import Asset, Collection, Item, ItemCollection, STACError
+from pystac import Asset, Collection, Item, ItemCollection, Link, STACError
 from yarl import URL
 
 from .client import Client, Clients
@@ -99,6 +99,8 @@ class Downloads:
         # Will fail if the stac object doesn't have a self href and there's
         # relative asset hrefs
         stac_object = make_asset_hrefs_absolute(stac_object)
+        if self_href := stac_object.get_self_href():
+            stac_object.add_link(Link(rel="derived_from", target=self_href))
         if file_name:
             stac_object.set_self_href(str(Path(root) / file_name))
         else:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -246,3 +246,17 @@ async def test_keep_non_downloaded(item: Item, tmp_path: Path) -> None:
 async def test_download_file(data_path: Path, tmp_path: Path) -> None:
     await stac_asset.download_file(str(data_path / "item.json"), tmp_path / "item.json")
     Item.from_file(tmp_path / "item.json")
+
+
+async def test_link_back(item: Item, tmp_path: Path) -> None:
+    item.make_asset_hrefs_absolute()
+    item.set_self_href(None)
+    await stac_asset.download_item(item, tmp_path, file_name="item.json")
+    item = Item.from_file(tmp_path / "item.json")
+    assert not item.get_links(rel="derived_from")
+
+    item.set_self_href("http://stac.test/item.json")
+    await stac_asset.download_item(item, tmp_path, file_name="item.json")
+    item = Item.from_file(tmp_path / "item.json")
+    link = item.get_links(rel="derived_from")[0]
+    assert link.href == "http://stac.test/item.json"


### PR DESCRIPTION
## Related issues and pull requests

- Closes #102

## Description

`derived_from` seemed better than `canonical`, since there might already be a `canonical` link and it doesn't make sense to have two.

## Checklist

- [x] Add tests
- [x] Update CHANGELOG
