### PR TITLE
Custom s3 endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Support for configuring a custom endpoint URL for `S3Client`.
+- Support for configuring a custom endpoint URL for `S3Client` ([#184](https://github.com/stac-utils/stac-asset/pull/184)
 - More `HttpClient` attributes to `Config` ([#177](https://github.com/stac-utils/stac-asset/pull/177))
 - `derived_from` link ([#178](https://github.com/stac-utils/stac-asset/pull/178))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Support for configuring a custom endpoint URL for `S3Client`.
 - More `HttpClient` attributes to `Config` ([#177](https://github.com/stac-utils/stac-asset/pull/177))
 - `derived_from` link ([#178](https://github.com/stac-utils/stac-asset/pull/178))
 

--- a/src/stac_asset/config.py
+++ b/src/stac_asset/config.py
@@ -84,6 +84,9 @@ class Config:
     s3_max_attempts: int = DEFAULT_S3_MAX_ATTEMPTS
     """The maximum number of attempts when downloading assets from s3."""
 
+    s3_endpoint_url: Optional[str] = None
+    """Set an optional custom endpoint url for s3"""
+
     def validate(self) -> None:
         """Validates this configuration.
 

--- a/src/stac_asset/config.py
+++ b/src/stac_asset/config.py
@@ -85,7 +85,7 @@ class Config:
     """The maximum number of attempts when downloading assets from s3."""
 
     s3_endpoint_url: Optional[str] = None
-    """Set an optional custom endpoint url for s3"""
+    """Set an optional custom endpoint url for s3."""
 
     def validate(self) -> None:
         """Validates this configuration.

--- a/src/stac_asset/s3_client.py
+++ b/src/stac_asset/s3_client.py
@@ -80,7 +80,7 @@ class S3Client(Client):
         """The maximum number of attempts."""
 
         self.endpoint_url: Optional[str] = endpoint_url
-        """Custom endpoint url for s3"""
+        """Custom endpoint url for s3."""
 
 
     async def open_url(

--- a/src/stac_asset/s3_client.py
+++ b/src/stac_asset/s3_client.py
@@ -54,7 +54,7 @@ class S3Client(Client):
         region_name: str = DEFAULT_S3_REGION_NAME,
         retry_mode: str = DEFAULT_S3_RETRY_MODE,
         max_attempts: int = DEFAULT_S3_MAX_ATTEMPTS,
-        endpoint_url: Optional[str] = None
+        endpoint_url: Optional[str] = None,
     ) -> None:
         super().__init__()
 
@@ -81,7 +81,6 @@ class S3Client(Client):
 
         self.endpoint_url: Optional[str] = endpoint_url
         """Custom endpoint url for s3."""
-
 
     async def open_url(
         self,
@@ -133,7 +132,10 @@ class S3Client(Client):
         else:
             config = botocore.config.Config(signature_version=UNSIGNED, retries=retries)
         return self.session.create_client(
-            "s3", region_name=self.region_name, endpoint_url=self.endpoint_url, config=config
+            "s3",
+            region_name=self.region_name,
+            endpoint_url=self.endpoint_url,
+            config=config,
         )
 
     def _params(self, url: URL) -> Dict[str, Any]:

--- a/src/stac_asset/s3_client.py
+++ b/src/stac_asset/s3_client.py
@@ -45,6 +45,7 @@ class S3Client(Client):
             region_name=config.s3_region_name,
             retry_mode=config.s3_retry_mode,
             max_attempts=config.s3_max_attempts,
+            endpoint_url=config.s3_endpoint_url,
         )
 
     def __init__(
@@ -53,6 +54,7 @@ class S3Client(Client):
         region_name: str = DEFAULT_S3_REGION_NAME,
         retry_mode: str = DEFAULT_S3_RETRY_MODE,
         max_attempts: int = DEFAULT_S3_MAX_ATTEMPTS,
+        endpoint_url: Optional[str] = None
     ) -> None:
         super().__init__()
 
@@ -76,6 +78,10 @@ class S3Client(Client):
 
         self.max_attempts: int = max_attempts
         """The maximum number of attempts."""
+
+        self.endpoint_url: Optional[str] = endpoint_url
+        """Custom endpoint url for s3"""
+
 
     async def open_url(
         self,
@@ -127,7 +133,7 @@ class S3Client(Client):
         else:
             config = botocore.config.Config(signature_version=UNSIGNED, retries=retries)
         return self.session.create_client(
-            "s3", region_name=self.region_name, config=config
+            "s3", region_name=self.region_name, endpoint_url=self.endpoint_url, config=config
         )
 
     def _params(self, url: URL) -> Dict[str, Any]:

--- a/tests/test_s3_client.py
+++ b/tests/test_s3_client.py
@@ -73,3 +73,25 @@ async def test_download_requester_pays_item(
         )
         == 19554
     )
+
+
+async def test_download_custom_endpoint(
+    tmp_path: Path, requester_pays_asset_href: str, custom_endpoint_url: str
+) -> None:
+    async with S3Client(requester_pays=True, endpoint_url=custom_endpoint_url) as client:
+        if not await client.has_credentials():
+            pytest.skip("aws credentials are invalid or not present")
+        await client.download_href(requester_pays_asset_href, tmp_path / "out.jpg")
+
+
+async def test_download_asset_custom_endpoint_from_config(
+    tmp_path: Path, requester_pays_asset_href: str, custom_endpoint_url: str
+) -> None:
+    
+    config = Config(warn=True, s3_requester_pays=True, s3_endpoint_url=custom_endpoint_url)
+    
+    s3_client = await S3Client.from_config(config=config)
+
+    if not await s3_client.has_credentials():
+        pytest.skip("aws credentials are invalid or not present")
+    await s3_client.download_href(requester_pays_asset_href, tmp_path / "out.jpg")

--- a/tests/test_s3_client.py
+++ b/tests/test_s3_client.py
@@ -73,25 +73,3 @@ async def test_download_requester_pays_item(
         )
         == 19554
     )
-
-
-async def test_download_custom_endpoint(
-    tmp_path: Path, requester_pays_asset_href: str, custom_endpoint_url: str
-) -> None:
-    async with S3Client(requester_pays=True, endpoint_url=custom_endpoint_url) as client:
-        if not await client.has_credentials():
-            pytest.skip("aws credentials are invalid or not present")
-        await client.download_href(requester_pays_asset_href, tmp_path / "out.jpg")
-
-
-async def test_download_asset_custom_endpoint_from_config(
-    tmp_path: Path, requester_pays_asset_href: str, custom_endpoint_url: str
-) -> None:
-    
-    config = Config(warn=True, s3_requester_pays=True, s3_endpoint_url=custom_endpoint_url)
-    
-    s3_client = await S3Client.from_config(config=config)
-
-    if not await s3_client.has_credentials():
-        pytest.skip("aws credentials are invalid or not present")
-    await s3_client.download_href(requester_pays_asset_href, tmp_path / "out.jpg")


### PR DESCRIPTION
## Related issues and pull requests

N/A

## Description

This pull request adds support for configuring a custom endpoint URL for the S3Client. This enhancement allows users to specify their own S3 endpoint.
#### Testing
- Verified that S3Client connects to the specified custom endpoint URL.
- Ensured backward compatibility by confirming the default behavior when no custom URL is provided.

Note that this feature only works if you import the functions and use it in your own code; the CLI has not been updated at this time.

## Checklist

- [ ] Add tests
- [X] Update CHANGELOG
