### PR TITLE
fix: expand the list of exceptions on which we should retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Expand the list of exceptions on which we should retry for HTTP ([#195](https://github.com/stac-utils/stac-asset/pull/195))
+
 ## [0.4.1] - 2024-07-17
 
 ### Added

--- a/src/stac_asset/http_client.py
+++ b/src/stac_asset/http_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from types import TracebackType
 from typing import AsyncIterator, Optional, Type, TypeVar
 
-from aiohttp import ClientResponseError, ClientSession, ClientTimeout
+from aiohttp import ClientError, ClientSession, ClientTimeout
 from aiohttp_oauth2_client.client import OAuth2Client
 from aiohttp_oauth2_client.models.grant import GrantType
 from aiohttp_retry import JitterRetry, RetryClient
@@ -113,7 +113,7 @@ class HttpClient(Client):
             session = RetryClient(
                 client_session=session,
                 retry_options=JitterRetry(
-                    attempts=config.http_max_attempts, exceptions={ClientResponseError}
+                    attempts=config.http_max_attempts, exceptions={ClientError}
                 ),
             )
         return cls(session, config.http_check_content_type)


### PR DESCRIPTION
## Description

```python
>>> from aiohttp import ClientResponseError, ClientError, ServerDisconnectedError
>>> issubclass(ClientResponseError, ClientError)
True
>>> issubclass(ServerDisconnectedError, ClientError)
True
>>> issubclass(ServerDisconnectedError, ClientResponseError)
False
```

## Checklist

- [ ] Add tests
- [ ] Add docs
- [x] Update CHANGELOG
