### PR TITLE
Error on pytest warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,11 @@ module = [
 ]
 ignore_missing_imports = true
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+    "ignore:inheritance class OAuth2Client from ClientSession is discouraged:DeprecationWarning", # https://github.com/VITObelgium/aiohttp-oauth2-client/issues/1
+]
 
 [tool.ruff.lint]
 select = ["F", "E", "W", "I", "ERA", "RUF", "D"]


### PR DESCRIPTION
## Related issues and pull requests

- Ignore can be dropped when https://github.com/VITObelgium/aiohttp-oauth2-client/issues/1 is fixed

## Description

Includes ignore on aiohttp-oauth2-client deprecation warning.
