### PR TITLE
Improve max concurrent downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - `--http-timeout` option to the CLI ([#196](https://github.com/stac-utils/stac-asset/pull/196))
 - More info to CLI error reporting ([#200](https://github.com/stac-utils/stac-asset/pull/200))
+- `--max-concurrent-downloads` option to the CLI ([#204](https://github.com/stac-utils/stac-asset/pull/204))
 
 ### Fixed
 
 - Expand the list of exceptions on which we should retry for HTTP ([#195](https://github.com/stac-utils/stac-asset/pull/195))
 - `SkipAssetDownload` docstring ([#199](https://github.com/stac-utils/stac-asset/pull/199))
+- Fast failing when we hit `max_concurrent_downloads` ([#204](https://github.com/stac-utils/stac-asset/pull/204))
 
 ## [0.4.1] - 2024-07-17
 

--- a/src/stac_asset/_cli.py
+++ b/src/stac_asset/_cli.py
@@ -141,6 +141,11 @@ def cli() -> None:
     is_flag=True,
     show_default=True,
 )
+@click.option(
+    "--max-concurrent-downloads",
+    help="The maximum number of downloads that can be active at one time",
+    default=_functions.DEFAULT_MAX_CONCURRENT_DOWNLOADS,
+)
 # TODO add option to disable content type checking
 def download(
     href: Optional[str],
@@ -159,6 +164,7 @@ def download(
     keep: bool,
     fail_fast: bool,
     overwrite: bool,
+    max_concurrent_downloads: int,
 ) -> None:
     """Download STAC assets from an item or item collection.
 
@@ -197,6 +203,7 @@ def download(
             keep=keep,
             fail_fast=fail_fast,
             overwrite=overwrite,
+            max_concurrent_downloads=max_concurrent_downloads,
         )
     )
 
@@ -218,6 +225,7 @@ async def download_async(
     keep: bool,
     fail_fast: bool,
     overwrite: bool,
+    max_concurrent_downloads: int,
 ) -> None:
     config = Config(
         alternate_assets=alternate_assets,
@@ -263,6 +271,7 @@ async def download_async(
                 infer_file_name=False,
                 config=config,
                 messages=messages,
+                max_concurrent_downloads=max_concurrent_downloads,
             )
 
     elif type_ == "FeatureCollection":
@@ -276,6 +285,7 @@ async def download_async(
                 file_name=file_name,
                 config=config,
                 messages=messages,
+                max_concurrent_downloads=max_concurrent_downloads,
             )
 
     else:

--- a/src/stac_asset/blocking.py
+++ b/src/stac_asset/blocking.py
@@ -25,6 +25,7 @@ def download_item(
     messages: Optional[MessageQueue] = None,
     clients: Optional[List[Client]] = None,
     keep_non_downloaded: bool = False,
+    max_concurrent_downloads: int = _functions.DEFAULT_MAX_CONCURRENT_DOWNLOADS,
 ) -> Item:
     """Downloads an item to the local filesystem, synchronously.
 
@@ -40,6 +41,8 @@ def download_item(
         clients: Pre-configured clients to use for access
         keep_non_downloaded: Keep all assets on the item, even if they're not
             downloaded.
+        max_concurrent_downloads: The maximum number of downloads that can be
+            active at one time.
 
     Returns:
         Item: The `~pystac.Item`, with the updated asset hrefs and self href.
@@ -57,6 +60,7 @@ def download_item(
             messages=messages,
             clients=clients,
             keep_non_downloaded=keep_non_downloaded,
+            max_concurrent_downloads=max_concurrent_downloads,
         )
     )
 
@@ -69,6 +73,7 @@ def download_collection(
     messages: Optional[MessageQueue] = None,
     clients: Optional[List[Client]] = None,
     keep_non_downloaded: bool = False,
+    max_concurrent_downloads: int = _functions.DEFAULT_MAX_CONCURRENT_DOWNLOADS,
 ) -> Collection:
     """Downloads a collection to the local filesystem, synchronously.
 
@@ -85,6 +90,8 @@ def download_collection(
         clients: Pre-configured clients to use for access
         keep_non_downloaded: Keep all assets on the item, even if they're not
             downloaded.
+        max_concurrent_downloads: The maximum number of downloads that can be
+            active at one time.
 
     Returns:
         Collection: The collection, with updated asset hrefs
@@ -101,6 +108,7 @@ def download_collection(
             messages=messages,
             clients=clients,
             keep_non_downloaded=keep_non_downloaded,
+            max_concurrent_downloads=max_concurrent_downloads,
         )
     )
 
@@ -114,6 +122,7 @@ def download_item_collection(
     messages: Optional[MessageQueue] = None,
     clients: Optional[List[Client]] = None,
     keep_non_downloaded: bool = False,
+    max_concurrent_downloads: int = _functions.DEFAULT_MAX_CONCURRENT_DOWNLOADS,
 ) -> ItemCollection:
     """Downloads an item collection to the local filesystem, synchronously.
 
@@ -129,6 +138,8 @@ def download_item_collection(
         clients: Pre-configured clients to use for access
         keep_non_downloaded: Keep all assets on the item, even if they're not
             downloaded.
+        max_concurrent_downloads: The maximum number of downloads that can be
+            active at one time.
 
     Returns:
         ItemCollection: The item collection, with updated asset hrefs
@@ -146,6 +157,7 @@ def download_item_collection(
             clients=clients,
             keep_non_downloaded=keep_non_downloaded,
             path_template=path_template,
+            max_concurrent_downloads=max_concurrent_downloads,
         )
     )
 


### PR DESCRIPTION
## Related issues and pull requests

- Closes #201 

## Description

Better semaphore usage to enforce `max_concurrent_downloads`. Also bubble up `max_concurrent_downloads` all the way to the CLI. cc @drnextgis 

## Checklist

- [x] Add docs
- [x] Update CHANGELOG
