### PR TITLE
Warn not error on content type, by default

### DIFF
--- a/src/stac_asset/config.py
+++ b/src/stac_asset/config.py
@@ -67,7 +67,7 @@ class Config:
     http_max_attempts: int = DEFAULT_HTTP_MAX_ATTEMPTS
     """The maximum number of attempts when downloading assets via http."""
 
-    http_check_content_type: bool = True
+    http_assert_content_type: bool = False
     """If true, check the asset's content type against the response from the server."""
 
     http_headers: dict[str, str] = field(default_factory=dict)

--- a/src/stac_asset/planetary_computer_client.py
+++ b/src/stac_asset/planetary_computer_client.py
@@ -56,10 +56,10 @@ class PlanetaryComputerClient(HttpClient):
     def __init__(
         self,
         session: ClientSession,
-        check_content_type: bool,
+        assert_content_type: bool,
         sas_token_endpoint: str = DEFAULT_SAS_TOKEN_ENDPOINT,
     ) -> None:
-        super().__init__(session, check_content_type)
+        super().__init__(session, assert_content_type)
         self._cache: dict[URL, _Token] = dict()
         self._cache_lock: Lock = Lock()
 


### PR DESCRIPTION
## Related issues and pull requests

- Closes #223 

## Description

@scottyhq any chance you have time to check this one out? I don't have a content_type-non-complaint server at the ready.

