### PR TITLE
a guess of the earthdataclient case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added logic to select `EarthdataClient` when appropriate ([#235](https://github.com/stac-utils/stac-asset/pull/235))
+
 ## [0.4.4] - 2024-10-23
 
 ### Changed

--- a/src/stac_asset/client.py
+++ b/src/stac_asset/client.py
@@ -205,6 +205,7 @@ class Clients:
         Returns:
             Client: An instance of that client.
         """
+        from .earthdata_client import EarthdataClient
         from .filesystem_client import FilesystemClient
         from .http_client import HttpClient
         from .planetary_computer_client import PlanetaryComputerClient
@@ -217,6 +218,8 @@ class Clients:
             client_class = S3Client
         elif url.host.endswith("blob.core.windows.net"):
             client_class = PlanetaryComputerClient
+        elif url.scheme == "https" and "earthdata" in url.host:
+            client_class = EarthdataClient
         elif url.scheme == "http" or url.scheme == "https":
             client_class = HttpClient
         else:

--- a/tests/test_earthdata_client.py
+++ b/tests/test_earthdata_client.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from stac_asset import Config, EarthdataClient
+from stac_asset.client import Clients
 
 pytestmark = [
     pytest.mark.skipif(
@@ -11,12 +12,18 @@ pytestmark = [
         reason="EARTHDATA_PAT is not set",
     ),
     pytest.mark.asyncio,
-    pytest.mark.network_access,
 ]
 
 
+@pytest.mark.network_access
 async def test_download_href(tmp_path: Path) -> None:
     href = "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/MYD11A1.061/MYD11A1.A2023145.h14v17.061.2023146183035/MYD11A1.A2023145.h14v17.061.2023146183035.hdf"
     async with await EarthdataClient.from_config(Config()) as client:
         await client.download_href(href, tmp_path / "out.hdf")
         assert os.path.getsize(tmp_path / "out.hdf") == 197419
+
+
+async def test_get_earthdata_client() -> None:
+    href = "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/MOD21A1D.061/MOD21A1D.A2020253.h08v05.061.2020346022258/MOD21A1D.A2020253.h08v05.061.2020346022258.hdf"
+    clients = Clients(Config())
+    assert isinstance(await clients.get_client(href=href), EarthdataClient)


### PR DESCRIPTION
## Related issues and pull requests

- Related to #234 in that there wasn't a path to using the earthdata client.

## Description

Sets the default client to be EarthdataClient when "earthdata" is in a https url's hostname.

## Checklist

- [x] Add tests
- [ ] Add docs
- [x] Update CHANGELOG
