### PR TITLE
Allow http headers on cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- `--http-header` CLI argument ([#238](https://github.com/stac-utils/stac-asset/pull/238))
+
 ## [0.4.5] - 2024-10-29
 
 ### Added

--- a/src/stac_asset/_cli.py
+++ b/src/stac_asset/_cli.py
@@ -117,6 +117,12 @@ def cli() -> None:
     default=DEFAULT_HTTP_CLIENT_TIMEOUT,
 )
 @click.option(
+    "--http-header",
+    "http_headers",
+    help="key=value header pairs to use when making HTTP requests",
+    multiple=True,
+)
+@click.option(
     "-k",
     "--keep",
     help=(
@@ -169,6 +175,7 @@ def download(
     s3_max_attempts: int,
     http_max_attempts: int,
     http_timeout: int,
+    http_headers: list[str],
     keep: bool,
     fail_fast: bool,
     overwrite: bool,
@@ -217,6 +224,7 @@ def download(
             s3_max_attempts,
             http_max_attempts,
             http_timeout,
+            http_headers=http_headers,
             keep=keep,
             fail_fast=fail_fast,
             overwrite=overwrite,
@@ -240,12 +248,20 @@ async def download_async(
     s3_max_attempts: int,
     http_max_attempts: int,
     http_timeout: int,
+    http_headers: list[str],
     keep: bool,
     fail_fast: bool,
     overwrite: bool,
     max_concurrent_downloads: int,
     stream: bool | None,
 ) -> None:
+    http_headers_dict = {}
+    for http_header in http_headers:
+        values = http_header.split("=", 1)
+        if len(values) == 2:
+            http_headers_dict[values[0]] = values[1]
+        else:
+            http_headers_dict[values[0]] = ""
     config = Config(
         alternate_assets=alternate_assets,
         include=include,


### PR DESCRIPTION
## Related issues and pull requests

- Closes #237

## Description

Add `--http-header`, which can be specified multiple times, to CLI.

@scottyhq your example would then look like:

```shell
stac-client search https://api.canopy.umbra.space/v2/stac/ \
   --headers "authorization=Bearer $UMBRA_API_TOKEN" \
   --query "umbra:task_id=644cc5e9-8702-44d8-a154-235d3c8233f2" \
   | stac-asset download \
         --http-header "authorization=Bearer $UMBRA_API_TOKEN" \
         -i "2024-10-28-19-13-59_UMBRA-08_MM.tif"
```

Can you check this branch and see if that works for you? 🙇🏼 

## Checklist

- [ ] Add tests
- [x] Add docs
- [x] Update CHANGELOG
