### PR TITLE
Add names to clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - `--http-header` CLI argument ([#238](https://github.com/stac-utils/stac-asset/pull/238))
+- `--client` CLI argument, names to clients ([#239](https://github.com/stac-utils/stac-asset/pull/239))
 
 ## [0.4.5] - 2024-10-29
 

--- a/src/stac_asset/__init__.py
+++ b/src/stac_asset/__init__.py
@@ -24,7 +24,7 @@ from ._functions import (
     open_href,
     read_href,
 )
-from .client import Client
+from .client import Client, get_client_classes
 from .config import Config
 from .earthdata_client import EarthdataClient
 from .errors import (
@@ -65,6 +65,7 @@ __all__ = [
     "download_item",
     "download_item_collection",
     "download_file",
+    "get_client_classes",
     "open_href",
     "read_href",
 ]

--- a/src/stac_asset/_cli.py
+++ b/src/stac_asset/_cli.py
@@ -18,7 +18,7 @@ from click import Choice
 from pystac import Asset, Item, ItemCollection
 
 from . import Config, ErrorStrategy, _functions
-from .client import Clients
+from .client import Clients, get_client_classes
 from .config import (
     DEFAULT_HTTP_CLIENT_TIMEOUT,
     DEFAULT_HTTP_MAX_ATTEMPTS,
@@ -64,6 +64,7 @@ def cli() -> None:
 @click.option(
     "-c",
     "--client",
+    type=Choice([c.name for c in get_client_classes()]),
     help="Set the client to use for all downloads. If not "
     "provided, the client will be guessed from the asset href.",
 )

--- a/src/stac_asset/_cli.py
+++ b/src/stac_asset/_cli.py
@@ -62,6 +62,12 @@ def cli() -> None:
 @click.argument("href", required=False)
 @click.argument("directory", required=False)
 @click.option(
+    "-c",
+    "--client",
+    help="Set the client to use for all downloads. If not "
+    "provided, the client will be guessed from the asset href.",
+)
+@click.option(
     "-p",
     "--path-template",
     help="String to be interpolated to specify where to store downloaded files",
@@ -164,6 +170,7 @@ def cli() -> None:
 def download(
     href: str | None,
     directory: str | None,
+    client: str | None,
     path_template: str | None,
     alternate_assets: list[str],
     include: list[str],
@@ -213,6 +220,7 @@ def download(
         download_async(
             href,
             directory,
+            client,
             path_template,
             alternate_assets,
             include,
@@ -237,6 +245,7 @@ def download(
 async def download_async(
     href: str | None,
     directory: str | None,
+    client: str | None,
     path_template: str | None,
     alternate_assets: list[str],
     include: list[str],
@@ -275,6 +284,7 @@ async def download_async(
         warn=not fail_fast,
         fail_fast=fail_fast,
         overwrite=overwrite,
+        client_override=client,
     )
 
     input_dict = await read_as_dict(href, config)

--- a/src/stac_asset/client.py
+++ b/src/stac_asset/client.py
@@ -250,20 +250,19 @@ class Clients:
 
 
 def _get_client_class_by_name(name: str) -> type[Client]:
-    from .earthdata_client import EarthdataClient
-    from .filesystem_client import FilesystemClient
-    from .http_client import HttpClient
-    from .planetary_computer_client import PlanetaryComputerClient
-    from .s3_client import S3Client
-
-    client_classes: list[type[Client]] = [
-        EarthdataClient,
-        FilesystemClient,
-        HttpClient,
-        PlanetaryComputerClient,
-        S3Client,
-    ]
-    for client_class in client_classes:
+    for client_class in get_client_classes():
         if client_class.name == name:
             return client_class
     raise ValueError(f"no client with name: {name}")
+
+
+def get_client_classes() -> list[type[Client]]:
+    """Returns a list of all known subclasses of Client."""
+
+    # https://stackoverflow.com/questions/3862310/how-to-find-all-the-subclasses-of-a-class-given-its-name
+    def all_subclasses(cls: type[Client]) -> set[type[Client]]:
+        return set(cls.__subclasses__()).union(
+            [s for c in cls.__subclasses__() for s in all_subclasses(c)]
+        )
+
+    return list(all_subclasses(Client))  # type: ignore

--- a/src/stac_asset/config.py
+++ b/src/stac_asset/config.py
@@ -61,6 +61,12 @@ class Config:
     overwrite: bool = False
     """Download files even if they already exist locally."""
 
+    client_override: str | None = None
+    """Use the same client for all asset requests.
+
+    If not set, each asset's client will be guessed from its href.
+    """
+
     http_client_timeout: float | None = DEFAULT_HTTP_CLIENT_TIMEOUT
     """Total number of seconds for the whole request."""
 

--- a/src/stac_asset/earthdata_client.py
+++ b/src/stac_asset/earthdata_client.py
@@ -19,6 +19,8 @@ class EarthdataClient(HttpClient):
     3. Use :py:meth:`EarthdataClient.from_config()` to create a new client.
     """
 
+    name = "earthdata"
+
     @classmethod
     async def from_config(cls, config: Config) -> EarthdataClient:
         """Logs in to Earthdata and returns the default earthdata client.

--- a/src/stac_asset/filesystem_client.py
+++ b/src/stac_asset/filesystem_client.py
@@ -18,6 +18,8 @@ class FilesystemClient(Client):
     Mostly used for testing, but could be useful in some real-world cases.
     """
 
+    name = "filesystem"
+
     async def open_url(
         self,
         url: URL,

--- a/src/stac_asset/http_client.py
+++ b/src/stac_asset/http_client.py
@@ -29,6 +29,8 @@ class HttpClient(Client):
     Configure the session to customize its behavior.
     """
 
+    name = "http"
+
     @classmethod
     async def from_config(cls: type[T], config: Config) -> T:
         """Creates an HTTP client with an aiohttp session object.

--- a/src/stac_asset/planetary_computer_client.py
+++ b/src/stac_asset/planetary_computer_client.py
@@ -53,6 +53,8 @@ class PlanetaryComputerClient(HttpClient):
     thanks Tom Augspurger!
     """
 
+    name = "planetary-computer"
+
     def __init__(
         self,
         session: ClientSession,

--- a/src/stac_asset/s3_client.py
+++ b/src/stac_asset/s3_client.py
@@ -31,6 +31,8 @@ class S3Client(Client):
     for instructions.
     """
 
+    name = "s3"
+
     @classmethod
     async def from_config(cls, config: Config) -> S3Client:
         """Creates an s3 client from a config.


### PR DESCRIPTION
## Related issues and pull requests

- Closes #93 
- Closes #234 
- Follow on issue: https://github.com/stac-utils/stac-asset/issues/240

## Description

Bit a YOLO implementation, but I tested locally by forcing s3:

```shell
$ stac-asset download --client s3 tests/data/item.json 2>&1 | grep s3_client -A 1
  File "/Users/gadomski/Code/stac-utils/stac-asset/src/stac_asset/s3_client.py", line 113, in open_url
    response = await client.get_object(**self._params(url))
```

## Checklist

- [ ] Add tests
- [x] Add docs
- [x] Update CHANGELOG
