### PR TITLE
feat: support OAuth2 via HTTP client middleware instead of subclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Handle OAuth2 support via middleware of the HTTP client instead of a subclass ([252](https://github.com/stac-utils/stac-asset/pull/252))
+
 ## [0.4.6] - 2024-11-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,11 @@ requires-python = ">=3.10"
 dependencies = [
     "aiofiles>=23.1.0",
     "aiobotocore>=2.5.0",
-    "aiohttp>=3.8.4",
+    "aiohttp~=3.12",
     "pystac>=1.8.4",
     "python-dateutil>=2.7.0",
     "yarl>=1.9.2",
-    "aiohttp-oauth2-client>=1.0.2",
+    "aiohttp-oauth2-client~=2.0",
     "aiohttp-retry>=2.8.3",
 ]
 
@@ -77,7 +77,6 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    "ignore:inheritance class OAuth2Client from ClientSession is discouraged:DeprecationWarning", # https://github.com/VITObelgium/aiohttp-oauth2-client/issues/1
     "ignore:datetime.datetime.utcnow.*:DeprecationWarning:botocore",                              # https://github.com/boto/boto3/issues/3889
 ]
 asyncio_default_fixture_loop_scope = "function"

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,11 +1,11 @@
 import pytest
-from aiohttp_oauth2_client.client import OAuth2Client
 from aiohttp_oauth2_client.grant.authorization_code import AuthorizationCodeGrant
 from aiohttp_oauth2_client.grant.client_credentials import ClientCredentialsGrant
 from aiohttp_oauth2_client.grant.device_code import DeviceCodeGrant
 from aiohttp_oauth2_client.grant.resource_owner_password_credentials import (
     ResourceOwnerPasswordCredentialsGrant,
 )
+from aiohttp_oauth2_client.middleware import OAuth2Middleware
 
 from stac_asset import Config, HttpClient
 
@@ -33,8 +33,9 @@ async def test_oauth2_device_code_config() -> None:
         oauth2_client_id="public",
     )
     async with await HttpClient.from_config(config) as client:
-        assert isinstance(client.session, OAuth2Client)
-        assert isinstance(client.session.grant, DeviceCodeGrant)
+        middlewares = client.session._client._middlewares
+        assert isinstance(middlewares[0], OAuth2Middleware)
+        assert isinstance(middlewares[0].grant, DeviceCodeGrant)
 
 
 async def test_oauth2_authorization_code_config() -> None:
@@ -46,8 +47,9 @@ async def test_oauth2_authorization_code_config() -> None:
         oauth2_pkce=False,
     )
     async with await HttpClient.from_config(config) as client:
-        assert isinstance(client.session, OAuth2Client)
-        assert isinstance(client.session.grant, AuthorizationCodeGrant)
+        middlewares = client.session._client._middlewares
+        assert isinstance(middlewares[0], OAuth2Middleware)
+        assert isinstance(middlewares[0].grant, AuthorizationCodeGrant)
 
 
 async def test_oauth2_password_config() -> None:
@@ -59,8 +61,9 @@ async def test_oauth2_password_config() -> None:
         oauth2_password="secret",
     )
     async with await HttpClient.from_config(config) as client:
-        assert isinstance(client.session, OAuth2Client)
-        assert isinstance(client.session.grant, ResourceOwnerPasswordCredentialsGrant)
+        middlewares = client.session._client._middlewares
+        assert isinstance(middlewares[0], OAuth2Middleware)
+        assert isinstance(middlewares[0].grant, ResourceOwnerPasswordCredentialsGrant)
 
 
 async def test_oauth2_client_credentials_config() -> None:
@@ -71,5 +74,6 @@ async def test_oauth2_client_credentials_config() -> None:
         oauth2_client_secret="secret",
     )
     async with await HttpClient.from_config(config) as client:
-        assert isinstance(client.session, OAuth2Client)
-        assert isinstance(client.session.grant, ClientCredentialsGrant)
+        middlewares = client.session._client._middlewares
+        assert isinstance(middlewares[0], OAuth2Middleware)
+        assert isinstance(middlewares[0].grant, ClientCredentialsGrant)


### PR DESCRIPTION
## Related issues and pull requests
- Fixes issue described in https://github.com/VITObelgium/aiohttp-oauth2-client/issues/1

## Description
Instead of subclassing the aiohttp ClientSession to support authentication mechanisms, aiohttp now offers support for client middleware since v3.12.0. This PR fixes the warning you got when instantiating a subclass of the ClientSession and now supports OAuth2 via this middleware mechanism.

## Checklist

- [x] Add tests
- [x] Add docs
- [x] Update CHANGELOG
